### PR TITLE
Patch recursive project directories

### DIFF
--- a/bin/manifold
+++ b/bin/manifold
@@ -4,6 +4,6 @@
 lib_path = File.expand_path("../lib", Dir.pwd)
 $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
 
-require "manifold/cli"
+require "manifold"
 
 Manifold::CLI.start(ARGV)

--- a/lib/manifold.rb
+++ b/lib/manifold.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "logger"
 require "pathname"
 require "thor"
 require "yaml"

--- a/lib/manifold/cli.rb
+++ b/lib/manifold/cli.rb
@@ -33,8 +33,8 @@ module Manifold
       end
 
       desc "add VECTOR_NAME", "Add a new vector configuration"
-      def add(name, project: API::Project.new(File.basename(Dir.getwd)))
-        vector = API::Vector.new(name, project: project)
+      def add(name)
+        vector = API::Vector.new(name)
         vector.add
         logger.info "Created vector configuration for '#{name}'."
       end

--- a/lib/manifold/cli.rb
+++ b/lib/manifold/cli.rb
@@ -41,8 +41,8 @@ module Manifold
     }
 
     desc "add WORKSPACE_NAME", "Add a new workspace to a project"
-    def add(name, project: API::Project.new(File.basename(Dir.getwd)))
-      workspace = API::Workspace.new(name, project: project)
+    def add(name)
+      workspace = API::Workspace.new(name)
       workspace.add
       logger.info "Added workspace '#{name}' with tables and routines directories."
     end

--- a/lib/manifold/project/vector.rb
+++ b/lib/manifold/project/vector.rb
@@ -4,15 +4,14 @@ module Manifold
   module API
     # Describes the entities for whom metrics are calculated.
     class Vector
-      attr_reader :name, :project, :template_path
+      attr_reader :name, :template_path
 
-      DEFAULT_TEMPLATE_PATH = Pathname.pwd.join(
-        "lib", "manifold", "templates", "vector_template.yml"
+      DEFAULT_TEMPLATE_PATH = File.expand_path(
+        "../templates/vector_template.yml", __dir__
       ).freeze
 
-      def initialize(name, project:, template_path: DEFAULT_TEMPLATE_PATH)
+      def initialize(name, template_path: DEFAULT_TEMPLATE_PATH)
         self.name = name
-        self.project = project
         self.template_path = Pathname(template_path)
       end
 
@@ -23,10 +22,10 @@ module Manifold
 
       private
 
-      attr_writer :name, :project, :template_path
+      attr_writer :name, :template_path
 
       def directory
-        project.directory.join("vectors")
+        Pathname.pwd.join("vectors")
       end
 
       def config_path

--- a/lib/manifold/project/workspace.rb
+++ b/lib/manifold/project/workspace.rb
@@ -22,11 +22,11 @@ module Manifold
       end
 
       def tables_directory
-        project.workspaces_directory.join(name, "tables")
+        directory.join("tables")
       end
 
       def routines_directory
-        project.workspaces_directory.join(name, "routines")
+        directory.join("routines")
       end
 
       def manifold_file
@@ -40,10 +40,14 @@ module Manifold
       end
 
       def manifold_path
-        project.workspaces_directory.join(name, "manifold.yml")
+        directory.join("manifold.yml")
       end
 
       private
+
+      def directory
+        project.directory.join("workspaces", name)
+      end
 
       attr_writer :name, :project, :template_path
     end

--- a/lib/manifold/project/workspace.rb
+++ b/lib/manifold/project/workspace.rb
@@ -4,15 +4,14 @@ module Manifold
   module API
     # Encapsulates a single manifold.
     class Workspace
-      attr_reader :name, :project, :template_path
+      attr_reader :name, :template_path
 
-      DEFAULT_TEMPLATE_PATH = Pathname.pwd.join(
-        "lib", "manifold", "templates", "workspace_template.yml"
-      )
+      DEFAULT_TEMPLATE_PATH = File.expand_path(
+        "../templates/workspace_template.yml", __dir__
+      ).freeze
 
-      def initialize(name, project:, template_path: DEFAULT_TEMPLATE_PATH)
+      def initialize(name, template_path: DEFAULT_TEMPLATE_PATH)
         self.name = name
-        self.project = project
         self.template_path = template_path
       end
 
@@ -46,10 +45,10 @@ module Manifold
       private
 
       def directory
-        project.directory.join("workspaces", name)
+        Pathname.pwd.join("workspaces", name)
       end
 
-      attr_writer :name, :project, :template_path
+      attr_writer :name, :template_path
     end
   end
 end

--- a/spec/manifold/api/vector_spec.rb
+++ b/spec/manifold/api/vector_spec.rb
@@ -2,14 +2,13 @@
 
 RSpec.describe Manifold::API::Vector do
   include FakeFS::SpecHelpers
-  subject(:vector) { described_class.new(name, project: project) }
+  subject(:vector) { described_class.new(name) }
 
   include_context "with template files"
 
-  let(:project) { Manifold::API::Project.new("wetland") }
   let(:name) { "page" }
 
-  it { is_expected.to have_attributes(name: name, project: project) }
+  it { is_expected.to have_attributes(name: name) }
 
   describe ".add" do
     before { vector.add }

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -2,14 +2,13 @@
 
 RSpec.describe Manifold::API::Workspace do
   include FakeFS::SpecHelpers
-  subject(:workspace) { described_class.new(name, project: project) }
+  subject(:workspace) { described_class.new(name) }
 
   include_context "with template files"
 
-  let(:project) { Manifold::API::Project.new("wetland") }
   let(:name) { "people" }
 
-  it { is_expected.to have_attributes(name: name, project: project) }
+  it { is_expected.to have_attributes(name: name) }
 
   describe ".add" do
     before { workspace.add }

--- a/spec/manifold/cli_spec.rb
+++ b/spec/manifold/cli_spec.rb
@@ -81,8 +81,7 @@ RSpec.describe Manifold::CLI do
       end
 
       it "instantiates a new vector through the API" do
-        expect(Manifold::API::Vector).to have_received(:new)
-          .with(vector_name, project: mock_project)
+        expect(Manifold::API::Vector).to have_received(:new).with(vector_name)
       end
 
       it "adds the vector through the API" do

--- a/spec/manifold/cli_spec.rb
+++ b/spec/manifold/cli_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe Manifold::CLI do
       end
 
       it "instantiates a new workspace through the API" do
-        expect(Manifold::API::Workspace).to have_received(:new)
-          .with(workspace_name, project: mock_project)
+        expect(Manifold::API::Workspace).to have_received(:new).with(workspace_name)
       end
 
       it "adds the workspace through the API" do


### PR DESCRIPTION
The workspace and vectors calls currently recursively create project directories within a given project directory. This was happening because the vectors were being instantiated with a project configured with a directory set to `File.basename(Dir.getwd)`, which was creating a new <my_project> directory within the top level <my_project> directory.

This is best solved by just deleting the project argument altogether. We're only using it to locate a directory. Simpler to just assume we're in the project directory when we invoke the command. We could also add some `project.yaml` exists? type validation to guarantee you're running in a manifolds project.

Also patched a couple of miscellaneous runtime errors surfaced when actually invoking the gem against a real project.