### PR TITLE
Generate Terraform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.1.6'
           - '3.2.6'
           - '3.3.6'
+          - '3.4.1'
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require: rubocop-rspec
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/README.md
+++ b/README.md
@@ -61,7 +61,29 @@ manifold add <data_project_name>
 After you fill out the manifold.yml file, this command generates the necessary BigQuery schema files based on the specified dimensions and metrics.
 
 ```bash
-manifold generate <data_project_name> bq
+manifold generate
+```
+
+4. **Generate Terraform Configuration (Optional)**
+
+Manifold can optionally generate Terraform configurations for managing your BigQuery resources. To generate both BigQuery schemas and Terraform configurations, use the `--tf` flag:
+
+```bash
+manifold generate --tf
+```
+
+This will create:
+
+- A root `main.tf.json` file that sets up the Google Cloud provider and workspace modules
+- Individual workspace configurations in `workspaces/<workspace_name>/main.tf.json`
+- Dataset and table definitions that reference your generated BigQuery schemas
+
+The generated Terraform configurations use the Google Cloud provider and expect a `PROJECT_ID` variable to be set. You can apply these configurations using standard Terraform commands:
+
+```bash
+terraform init
+terraform plan -var="PROJECT_ID=your-project-id"
+terraform apply -var="PROJECT_ID=your-project-id"
 ```
 
 ## Manifold Configuration

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ This will create:
 - Individual workspace configurations in `workspaces/<workspace_name>/main.tf.json`
 - Dataset and table definitions that reference your generated BigQuery schemas
 
-The generated Terraform configurations use the Google Cloud provider and expect a `PROJECT_ID` variable to be set. You can apply these configurations using standard Terraform commands:
+The generated Terraform configurations use the Google Cloud provider and expect a `project_id` variable to be set. You can apply these configurations using standard Terraform commands:
 
 ```bash
 terraform init
-terraform plan -var="PROJECT_ID=your-project-id"
-terraform apply -var="PROJECT_ID=your-project-id"
+terraform plan -var="project_id=your-project-id"
+terraform apply -var="project_id=your-project-id"
 ```
 
 ## Manifold Configuration

--- a/lib/manifold/api/project.rb
+++ b/lib/manifold/api/project.rb
@@ -50,7 +50,7 @@ module Manifold
         workspaces.each_with_object({}) do |workspace, modules|
           modules[workspace.name] = {
             "source" => "./workspaces/#{workspace.name}",
-            "project_id" => "${var.project_id}"
+            "project_id" => "${var.PROJECT_ID}"
           }
         end
       end

--- a/lib/manifold/api/project.rb
+++ b/lib/manifold/api/project.rb
@@ -22,9 +22,9 @@ module Manifold
         @workspaces ||= workspace_directories.map { |dir| Workspace.from_directory(dir, logger:) }
       end
 
-      def generate(generate_terraform: false)
-        workspaces.each { |w| w.generate(generate_terraform:) }
-        generate_terraform_entrypoint if generate_terraform
+      def generate(with_terraform: false)
+        workspaces.each { |w| w.generate(with_terraform:) }
+        generate_terraform_entrypoint if with_terraform
       end
 
       def workspaces_directory

--- a/lib/manifold/api/project.rb
+++ b/lib/manifold/api/project.rb
@@ -22,9 +22,9 @@ module Manifold
         @workspaces ||= workspace_directories.map { |dir| Workspace.from_directory(dir, logger:) }
       end
 
-      def generate
-        workspaces.each(&:generate)
-        generate_terraform_entrypoint
+      def generate(generate_terraform: false)
+        workspaces.each { |w| w.generate(generate_terraform:) }
+        generate_terraform_entrypoint if generate_terraform
       end
 
       def workspaces_directory
@@ -44,19 +44,6 @@ module Manifold
       def generate_terraform_entrypoint
         config = Terraform::ProjectConfiguration.new(workspaces)
         config.write(directory.join("main.tf.json"))
-      end
-
-      def generate_workspace_modules
-        workspaces.each_with_object({}) do |workspace, modules|
-          modules[workspace.name] = {
-            "source" => "./workspaces/#{workspace.name}",
-            "project_id" => "${var.PROJECT_ID}"
-          }
-        end
-      end
-
-      def terraform_path
-        directory.join("main.tf.json")
       end
     end
   end

--- a/lib/manifold/api/project.rb
+++ b/lib/manifold/api/project.rb
@@ -42,30 +42,8 @@ module Manifold
       end
 
       def generate_terraform_entrypoint
-        terraform_config = {
-          "terraform" => {
-            "required_providers" => {
-              "google" => {
-                "source" => "hashicorp/google",
-                "version" => "~> 4.0"
-              }
-            }
-          },
-          "provider" => {
-            "google" => {
-              "project" => "${var.project_id}"
-            }
-          },
-          "variable" => {
-            "project_id" => {
-              "description" => "The GCP project ID where resources will be created",
-              "type" => "string"
-            }
-          },
-          "module" => generate_workspace_modules
-        }
-
-        terraform_path.write(JSON.pretty_generate(terraform_config))
+        config = Terraform::ProjectConfiguration.new(workspaces)
+        config.write(directory.join("main.tf.json"))
       end
 
       def generate_workspace_modules

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -26,11 +26,11 @@ module Manifold
         FileUtils.cp(template_path, manifold_path)
       end
 
-      def generate(generate_terraform: false)
+      def generate(with_terraform: false)
         return unless manifold_exists? && any_vectors?
 
         generate_dimensions
-        do_generate_terraform if generate_terraform
+        generate_terraform if with_terraform
         logger.info("Generated BigQuery dimensions table schema for workspace '#{name}'.")
       end
 
@@ -101,7 +101,7 @@ module Manifold
         manifold_yaml["vectors"]
       end
 
-      def do_generate_terraform
+      def generate_terraform
         config = Terraform::WorkspaceConfiguration.new(name)
         config.write(terraform_main_path)
       end

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -26,11 +26,11 @@ module Manifold
         FileUtils.cp(template_path, manifold_path)
       end
 
-      def generate
+      def generate(generate_terraform: false)
         return unless manifold_exists? && any_vectors?
 
         generate_dimensions
-        generate_terraform
+        do_generate_terraform if generate_terraform
         logger.info("Generated BigQuery dimensions table schema for workspace '#{name}'.")
       end
 
@@ -101,7 +101,7 @@ module Manifold
         manifold_yaml["vectors"]
       end
 
-      def generate_terraform
+      def do_generate_terraform
         config = Terraform::WorkspaceConfiguration.new(name)
         config.write(terraform_main_path)
       end

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -30,6 +30,7 @@ module Manifold
         return unless manifold_exists? && any_vectors?
 
         generate_dimensions
+        generate_terraform
         logger.info("Generated BigQuery dimensions table schema for workspace '#{name}'.")
       end
 
@@ -98,6 +99,57 @@ module Manifold
 
       def vectors
         manifold_yaml["vectors"]
+      end
+
+      def generate_terraform
+        generate_terraform_config
+        generate_terraform_variables
+      end
+
+      def generate_terraform_config
+        tf = {
+          "resource" => {
+            "google_bigquery_dataset" => {
+              name => {
+                "dataset_id" => name,
+                "project" => "${var.PROJECT_ID}",
+                "location" => "US"
+              }
+            },
+            "google_bigquery_table" => {
+              "dimensions" => {
+                "dataset_id" => name,
+                "project" => "var.PROJECT_ID",
+                "table_id" => "dimensions",
+                "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
+                "depends_on" => ["google_bigquery_dataset.#{name}"]
+              }
+            }
+          }
+        }
+
+        terraform_main_path.write(JSON.pretty_generate(tf))
+      end
+
+      def generate_terraform_variables
+        variables_config = {
+          "variable" => {
+            "PROJECT_ID" => {
+              "description" => "The GCP project ID where resources will be created",
+              "type" => "string"
+            }
+          }
+        }
+
+        terraform_variables_path.write(JSON.pretty_generate(variables_config))
+      end
+
+      def terraform_main_path
+        directory.join("main.tf.json")
+      end
+
+      def terraform_variables_path
+        directory.join("variables.tf.json")
       end
     end
   end

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -102,46 +102,8 @@ module Manifold
       end
 
       def generate_terraform
-        generate_terraform_config
-        generate_terraform_variables
-      end
-
-      def generate_terraform_config
-        tf = {
-          "resource" => {
-            "google_bigquery_dataset" => {
-              name => {
-                "dataset_id" => name,
-                "project" => "${var.PROJECT_ID}",
-                "location" => "US"
-              }
-            },
-            "google_bigquery_table" => {
-              "dimensions" => {
-                "dataset_id" => name,
-                "project" => "var.PROJECT_ID",
-                "table_id" => "dimensions",
-                "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
-                "depends_on" => ["google_bigquery_dataset.#{name}"]
-              }
-            }
-          }
-        }
-
-        terraform_main_path.write(JSON.pretty_generate(tf))
-      end
-
-      def generate_terraform_variables
-        variables_config = {
-          "variable" => {
-            "PROJECT_ID" => {
-              "description" => "The GCP project ID where resources will be created",
-              "type" => "string"
-            }
-          }
-        }
-
-        terraform_variables_path.write(JSON.pretty_generate(variables_config))
+        config = Terraform::WorkspaceConfiguration.new(name)
+        config.write(terraform_main_path)
       end
 
       def terraform_main_path

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -109,10 +109,6 @@ module Manifold
       def terraform_main_path
         directory.join("main.tf.json")
       end
-
-      def terraform_variables_path
-        directory.join("variables.tf.json")
-      end
     end
   end
 end

--- a/lib/manifold/cli.rb
+++ b/lib/manifold/cli.rb
@@ -47,8 +47,9 @@ module Manifold
 
     desc "generate", "Generate BigQuery schema for all workspaces in the project"
     def generate
-      name = Pathname.pwd.basename.to_s
-      project = API::Project.new(name, directory: Pathname.pwd, logger:)
+      path = Pathname.pwd
+      name = path.basename.to_s
+      project = API::Project.new(name, directory: path, logger:)
       project.generate
       logger.info "Generated BigQuery schema for all workspaces in the project."
     end

--- a/lib/manifold/cli.rb
+++ b/lib/manifold/cli.rb
@@ -51,7 +51,7 @@ module Manifold
       path = Pathname.pwd
       name = path.basename.to_s
       project = API::Project.new(name, directory: path, logger:)
-      project.generate(generate_terraform: options[:tf])
+      project.generate(with_terraform: options[:tf])
       logger.info "Generated BigQuery schema for all workspaces in the project."
     end
   end

--- a/lib/manifold/cli.rb
+++ b/lib/manifold/cli.rb
@@ -46,11 +46,12 @@ module Manifold
     end
 
     desc "generate", "Generate BigQuery schema for all workspaces in the project"
+    method_option :tf, type: :boolean, desc: "Generate Terraform configurations"
     def generate
       path = Pathname.pwd
       name = path.basename.to_s
       project = API::Project.new(name, directory: path, logger:)
-      project.generate
+      project.generate(generate_terraform: options[:tf])
       logger.info "Generated BigQuery schema for all workspaces in the project."
     end
   end

--- a/lib/manifold/terraform/configuration.rb
+++ b/lib/manifold/terraform/configuration.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Manifold
+  module Terraform
+    # Provides a base class for Terraform configuration files.
+    class Configuration
+      def as_json
+        raise NotImplementedError, "#{self.class} must implement #as_json"
+      end
+
+      def write(path)
+        path.write("#{JSON.pretty_generate(as_json)}\n")
+      end
+    end
+  end
+end

--- a/lib/manifold/terraform/project_configuration.rb
+++ b/lib/manifold/terraform/project_configuration.rb
@@ -39,7 +39,7 @@ module Manifold
       def provider_block
         {
           "google" => {
-            "project" => "${var.project_id}"
+            "project" => "${var.PROJECT_ID}"
           }
         }
       end
@@ -57,7 +57,7 @@ module Manifold
         workspaces.each_with_object({}) do |workspace, modules|
           modules[workspace.name] = {
             "source" => "./workspaces/#{workspace.name}",
-            "project_id" => "${var.project_id}"
+            "project_id" => "${var.PROJECT_ID}"
           }
         end
       end

--- a/lib/manifold/terraform/project_configuration.rb
+++ b/lib/manifold/terraform/project_configuration.rb
@@ -6,7 +6,7 @@ module Manifold
     class ProjectConfiguration < Configuration
       attr_reader :workspaces, :provider_version
 
-      DEFAULT_TERRAFORM_GOOGLE_PROVIDER_VERSION = "6.12.0"
+      DEFAULT_TERRAFORM_GOOGLE_PROVIDER_VERSION = "6.18.1"
 
       def initialize(workspaces, provider_version: DEFAULT_TERRAFORM_GOOGLE_PROVIDER_VERSION)
         super()

--- a/lib/manifold/terraform/project_configuration.rb
+++ b/lib/manifold/terraform/project_configuration.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Manifold
+  module Terraform
+    # Represents a Terraform configuration for a Manifold project.
+    class ProjectConfiguration < Configuration
+      attr_reader :workspaces
+
+      def initialize(workspaces)
+        super()
+        @workspaces = workspaces
+      end
+
+      def as_json
+        {
+          "terraform" => terraform_block,
+          "provider" => provider_block,
+          "variable" => variables_block,
+          "module" => workspace_modules
+        }
+      end
+
+      private
+
+      def terraform_block
+        {
+          "required_providers" => {
+            "google" => {
+              "source" => "hashicorp/google",
+              "version" => "~> 4.0"
+            }
+          }
+        }
+      end
+
+      def provider_block
+        {
+          "google" => {
+            "project" => "${var.project_id}"
+          }
+        }
+      end
+
+      def variables_block
+        {
+          "project_id" => {
+            "description" => "The GCP project ID where resources will be created",
+            "type" => "string"
+          }
+        }
+      end
+
+      def workspace_modules
+        workspaces.each_with_object({}) do |workspace, modules|
+          modules[workspace.name] = {
+            "source" => "./workspaces/#{workspace.name}",
+            "project_id" => "${var.project_id}"
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manifold/terraform/project_configuration.rb
+++ b/lib/manifold/terraform/project_configuration.rb
@@ -4,11 +4,14 @@ module Manifold
   module Terraform
     # Represents a Terraform configuration for a Manifold project.
     class ProjectConfiguration < Configuration
-      attr_reader :workspaces
+      attr_reader :workspaces, :provider_version
 
-      def initialize(workspaces)
+      DEFAULT_TERRAFORM_GOOGLE_PROVIDER_VERSION = "6.12.0"
+
+      def initialize(workspaces, provider_version: DEFAULT_TERRAFORM_GOOGLE_PROVIDER_VERSION)
         super()
         @workspaces = workspaces
+        @provider_version = provider_version
       end
 
       def as_json
@@ -27,7 +30,7 @@ module Manifold
           "required_providers" => {
             "google" => {
               "source" => "hashicorp/google",
-              "version" => "~> 4.0"
+              "version" => provider_version
             }
           }
         }

--- a/lib/manifold/terraform/project_configuration.rb
+++ b/lib/manifold/terraform/project_configuration.rb
@@ -39,7 +39,7 @@ module Manifold
       def provider_block
         {
           "google" => {
-            "project" => "${var.PROJECT_ID}"
+            "project" => "${var.project_id}"
           }
         }
       end
@@ -57,7 +57,7 @@ module Manifold
         workspaces.each_with_object({}) do |workspace, modules|
           modules[workspace.name] = {
             "source" => "./workspaces/#{workspace.name}",
-            "project_id" => "${var.PROJECT_ID}"
+            "project_id" => "${var.project_id}"
           }
         end
       end

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -47,7 +47,7 @@ module Manifold
           "dimensions" => {
             "dataset_id" => name,
             "project" => "${var.project_id}",
-            "table_id" => "dimensions",
+            "table_id" => "Dimensions",
             "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
             "depends_on" => ["google_bigquery_dataset.#{name}"]
           }

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Manifold
+  module Terraform
+    # Represents a Terraform configuration for a Manifold workspace.
+    class WorkspaceConfiguration < Configuration
+      attr_reader :name
+
+      def initialize(name)
+        super()
+        @name = name
+      end
+
+      def as_json
+        {
+          "resource" => {
+            "google_bigquery_dataset" => dataset_config,
+            "google_bigquery_table" => table_config
+          }
+        }
+      end
+
+      private
+
+      def dataset_config
+        {
+          name => {
+            "dataset_id" => name,
+            "project" => "${var.project_id}",
+            "location" => "US"
+          }
+        }
+      end
+
+      def table_config
+        {
+          "dimensions" => {
+            "dataset_id" => name,
+            "project" => "${var.project_id}",
+            "table_id" => "dimensions",
+            "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
+            "depends_on" => ["google_bigquery_dataset.#{name}"]
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -13,6 +13,7 @@ module Manifold
 
       def as_json
         {
+          "variable" => variables_block,
           "resource" => {
             "google_bigquery_dataset" => dataset_config,
             "google_bigquery_table" => table_config
@@ -22,11 +23,20 @@ module Manifold
 
       private
 
+      def variables_block
+        {
+          "PROJECT_ID" => {
+            "description" => "The GCP project ID where resources will be created",
+            "type" => "string"
+          }
+        }
+      end
+
       def dataset_config
         {
           name => {
             "dataset_id" => name,
-            "project" => "${var.project_id}",
+            "project" => "${var.PROJECT_ID}",
             "location" => "US"
           }
         }
@@ -36,7 +46,7 @@ module Manifold
         {
           "dimensions" => {
             "dataset_id" => name,
-            "project" => "${var.project_id}",
+            "project" => "${var.PROJECT_ID}",
             "table_id" => "dimensions",
             "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
             "depends_on" => ["google_bigquery_dataset.#{name}"]

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -25,7 +25,7 @@ module Manifold
 
       def variables_block
         {
-          "PROJECT_ID" => {
+          "project_id" => {
             "description" => "The GCP project ID where resources will be created",
             "type" => "string"
           }
@@ -36,7 +36,7 @@ module Manifold
         {
           name => {
             "dataset_id" => name,
-            "project" => "${var.PROJECT_ID}",
+            "project" => "${var.project_id}",
             "location" => "US"
           }
         }
@@ -46,7 +46,7 @@ module Manifold
         {
           "dimensions" => {
             "dataset_id" => name,
-            "project" => "${var.PROJECT_ID}",
+            "project" => "${var.project_id}",
             "table_id" => "dimensions",
             "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
             "depends_on" => ["google_bigquery_dataset.#{name}"]

--- a/manifold.gemspec
+++ b/manifold.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A CLI for managing data infrastructures in BigQuery"
   spec.homepage = "https://github.com/bustle/manifold"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/bustle/manifold"

--- a/spec/manifold/api/project_spec.rb
+++ b/spec/manifold/api/project_spec.rb
@@ -72,17 +72,19 @@ RSpec.describe Manifold::API::Project do
 
     it "includes workspace modules in the terraform configuration" do
       project.generate
-      config = JSON.parse(project.directory.join("main.tf.json").read)
-      expect(config["module"]).to include(
-        "workspace_one" => {
-          "source" => "./workspaces/workspace_one",
-          "project_id" => "${var.project_id}"
-        },
-        "workspace_two" => {
-          "source" => "./workspaces/workspace_two",
-          "project_id" => "${var.project_id}"
-        }
-      )
+      config = parse_terraform_config(project)
+      expect(config["module"]).to include(expected_workspace_modules)
+    end
+
+    def parse_terraform_config(project)
+      JSON.parse(project.directory.join("main.tf.json").read)
+    end
+
+    def expected_workspace_modules
+      {
+        "workspace_one" => { "source" => "./workspaces/workspace_one", "project_id" => "${var.project_id}" },
+        "workspace_two" => { "source" => "./workspaces/workspace_two", "project_id" => "${var.project_id}" }
+      }
     end
   end
 end

--- a/spec/manifold/api/project_spec.rb
+++ b/spec/manifold/api/project_spec.rb
@@ -60,21 +60,21 @@ RSpec.describe Manifold::API::Project do
       end
     end
 
-    context "with generate_terraform: false" do
+    context "with with_terraform: false" do
       it "does not generate terraform configurations" do
-        project.generate(generate_terraform: false)
+        project.generate(with_terraform: false)
         expect(project.directory.join("main.tf.json")).not_to be_file
       end
     end
 
-    context "with generate_terraform: true" do
+    context "with with_terraform: true" do
       it "creates a terraform configuration file" do
-        project.generate(generate_terraform: true)
+        project.generate(with_terraform: true)
         expect(project.directory.join("main.tf.json")).to be_file
       end
 
       it "includes workspace modules in the terraform configuration" do
-        project.generate(generate_terraform: true)
+        project.generate(with_terraform: true)
         config = parse_terraform_config(project)
         expect(config["module"]).to include(expected_workspace_modules)
       end

--- a/spec/manifold/api/project_spec.rb
+++ b/spec/manifold/api/project_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe Manifold::API::Project do
 
     def expected_workspace_modules
       {
-        "workspace_one" => { "source" => "./workspaces/workspace_one", "project_id" => "${var.project_id}" },
-        "workspace_two" => { "source" => "./workspaces/workspace_two", "project_id" => "${var.project_id}" }
+        "workspace_one" => { "source" => "./workspaces/workspace_one", "project_id" => "${var.PROJECT_ID}" },
+        "workspace_two" => { "source" => "./workspaces/workspace_two", "project_id" => "${var.PROJECT_ID}" }
       }
     end
   end

--- a/spec/manifold/api/project_spec.rb
+++ b/spec/manifold/api/project_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Manifold::API::Project do
 
       def expected_workspace_modules
         {
-          "workspace_one" => { "source" => "./workspaces/workspace_one", "project_id" => "${var.PROJECT_ID}" },
-          "workspace_two" => { "source" => "./workspaces/workspace_two", "project_id" => "${var.PROJECT_ID}" }
+          "workspace_one" => { "source" => "./workspaces/workspace_one", "project_id" => "${var.project_id}" },
+          "workspace_two" => { "source" => "./workspaces/workspace_two", "project_id" => "${var.project_id}" }
         }
       end
     end

--- a/spec/manifold/cli_spec.rb
+++ b/spec/manifold/cli_spec.rb
@@ -44,25 +44,25 @@ RSpec.describe Manifold::CLI do
 
     context "when called with --tf option" do
       before do
-        allow(mock_project).to receive(:generate).with(generate_terraform: true)
+        allow(mock_project).to receive(:generate).with(with_terraform: true)
       end
 
       it "generates terraform configurations" do
         cli.options = { tf: true }
         cli.generate
-        expect(mock_project).to have_received(:generate).with(generate_terraform: true)
+        expect(mock_project).to have_received(:generate).with(with_terraform: true)
       end
     end
 
     context "when called without --tf option" do
       before do
-        allow(mock_project).to receive(:generate).with(generate_terraform: false)
+        allow(mock_project).to receive(:generate).with(with_terraform: false)
       end
 
       it "does not generate terraform configurations" do
         cli.options = { tf: false }
         cli.generate
-        expect(mock_project).to have_received(:generate).with(generate_terraform: false)
+        expect(mock_project).to have_received(:generate).with(with_terraform: false)
       end
     end
   end

--- a/spec/manifold/cli_spec.rb
+++ b/spec/manifold/cli_spec.rb
@@ -39,6 +39,34 @@ RSpec.describe Manifold::CLI do
     end
   end
 
+  describe "#generate" do
+    subject(:cli) { described_class.new(logger: null_logger) }
+
+    context "when called with --tf option" do
+      before do
+        allow(mock_project).to receive(:generate).with(generate_terraform: true)
+      end
+
+      it "generates terraform configurations" do
+        cli.options = { tf: true }
+        cli.generate
+        expect(mock_project).to have_received(:generate).with(generate_terraform: true)
+      end
+    end
+
+    context "when called without --tf option" do
+      before do
+        allow(mock_project).to receive(:generate).with(generate_terraform: false)
+      end
+
+      it "does not generate terraform configurations" do
+        cli.options = { tf: false }
+        cli.generate
+        expect(mock_project).to have_received(:generate).with(generate_terraform: false)
+      end
+    end
+  end
+
   describe "#add" do
     subject(:cli) { described_class.new(logger: null_logger) }
 

--- a/spec/manifold/terraform/configuration_spec.rb
+++ b/spec/manifold/terraform/configuration_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::Terraform::Configuration do
+  include FakeFS::SpecHelpers
+
+  let(:test_configuration) do
+    Class.new(described_class) do
+      def as_json
+        { "test" => "config" }
+      end
+    end.new
+  end
+
+  describe "#write" do
+    let(:path) { Pathname.new("test.tf.json") }
+
+    it "writes pretty-printed JSON to the specified path" do
+      test_configuration.write(path)
+      expect(path.read).to eq(expected_json)
+    end
+
+    def expected_json
+      <<~JSON
+        {
+          "test": "config"
+        }
+      JSON
+    end
+  end
+end

--- a/spec/manifold/terraform/project_configuration_spec.rb
+++ b/spec/manifold/terraform/project_configuration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Manifold::Terraform::ProjectConfiguration do
     it "includes provider configuration" do
       expect(json["provider"]).to include(
         "google" => {
-          "project" => "${var.PROJECT_ID}"
+          "project" => "${var.project_id}"
         }
       )
     end
@@ -36,8 +36,8 @@ RSpec.describe Manifold::Terraform::ProjectConfiguration do
 
     it "writes workspace modules with correct project_id and source" do
       expect(json["module"]).to include(
-        "workspace_one" => { "project_id" => "${var.PROJECT_ID}", "source" => "./workspaces/workspace_one" },
-        "workspace_two" => { "project_id" => "${var.PROJECT_ID}", "source" => "./workspaces/workspace_two" }
+        "workspace_one" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_one" },
+        "workspace_two" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_two" }
       )
     end
   end

--- a/spec/manifold/terraform/project_configuration_spec.rb
+++ b/spec/manifold/terraform/project_configuration_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Manifold::Terraform::ProjectConfiguration do
   describe "#as_json" do
     subject(:json) { config.as_json }
 
-    it "includes required provider configuration" do
-      expect(json["terraform"]["required_providers"]).to include(expected_google_provider)
+    it "includes Google provider configuration" do
+      expect(json["terraform"]["required_providers"]["google"]["source"]).to eq("hashicorp/google")
     end
 
     it "includes provider configuration" do
@@ -39,15 +39,6 @@ RSpec.describe Manifold::Terraform::ProjectConfiguration do
         "workspace_one" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_one" },
         "workspace_two" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_two" }
       )
-    end
-
-    def expected_google_provider
-      {
-        "google" => {
-          "source" => "hashicorp/google",
-          "version" => "~> 4.0"
-        }
-      }
     end
   end
 end

--- a/spec/manifold/terraform/project_configuration_spec.rb
+++ b/spec/manifold/terraform/project_configuration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Manifold::Terraform::ProjectConfiguration do
     it "includes provider configuration" do
       expect(json["provider"]).to include(
         "google" => {
-          "project" => "${var.project_id}"
+          "project" => "${var.PROJECT_ID}"
         }
       )
     end
@@ -36,8 +36,8 @@ RSpec.describe Manifold::Terraform::ProjectConfiguration do
 
     it "writes workspace modules with correct project_id and source" do
       expect(json["module"]).to include(
-        "workspace_one" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_one" },
-        "workspace_two" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_two" }
+        "workspace_one" => { "project_id" => "${var.PROJECT_ID}", "source" => "./workspaces/workspace_one" },
+        "workspace_two" => { "project_id" => "${var.PROJECT_ID}", "source" => "./workspaces/workspace_two" }
       )
     end
   end

--- a/spec/manifold/terraform/project_configuration_spec.rb
+++ b/spec/manifold/terraform/project_configuration_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::Terraform::ProjectConfiguration do
+  include FakeFS::SpecHelpers
+
+  subject(:config) { described_class.new(workspaces) }
+
+  let(:workspaces) do
+    [
+      instance_double(Manifold::API::Workspace, name: "workspace_one"),
+      instance_double(Manifold::API::Workspace, name: "workspace_two")
+    ]
+  end
+
+  describe "#as_json" do
+    subject(:json) { config.as_json }
+
+    it "includes required provider configuration" do
+      expect(json["terraform"]["required_providers"]).to include(expected_google_provider)
+    end
+
+    it "includes provider configuration" do
+      expect(json["provider"]).to include(
+        "google" => {
+          "project" => "${var.project_id}"
+        }
+      )
+    end
+
+    it "includes project_id variable" do
+      expect(json["variable"]["project_id"]).to include(
+        "description" => "The GCP project ID where resources will be created",
+        "type" => "string"
+      )
+    end
+
+    it "writes workspace modules with correct project_id and source" do
+      expect(json["module"]).to include(
+        "workspace_one" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_one" },
+        "workspace_two" => { "project_id" => "${var.project_id}", "source" => "./workspaces/workspace_two" }
+      )
+    end
+
+    def expected_google_provider
+      {
+        "google" => {
+          "source" => "hashicorp/google",
+          "version" => "~> 4.0"
+        }
+      }
+    end
+  end
+end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
   describe "#as_json" do
     subject(:json) { config.as_json }
 
+    it "includes PROJECT_ID variable" do
+      expect(json["variable"]["PROJECT_ID"]).to include(
+        "description" => "The GCP project ID where resources will be created",
+        "type" => "string"
+      )
+    end
+
     it "includes dataset configuration" do
       expect(json["resource"]["google_bigquery_dataset"]).to include(
         name => expected_dataset
@@ -25,7 +32,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
     def expected_dataset
       {
         "dataset_id" => name,
-        "project" => "${var.project_id}",
+        "project" => "${var.PROJECT_ID}",
         "location" => "US"
       }
     end
@@ -33,7 +40,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
     def expected_dimensions_table
       {
         "dataset_id" => name,
-        "project" => "${var.project_id}",
+        "project" => "${var.PROJECT_ID}",
         "table_id" => "dimensions",
         "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
         "depends_on" => ["google_bigquery_dataset.#{name}"]

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
+  include FakeFS::SpecHelpers
+
+  subject(:config) { described_class.new(name) }
+
+  let(:name) { "analytics" }
+
+  describe "#as_json" do
+    subject(:json) { config.as_json }
+
+    it "includes dataset configuration" do
+      expect(json["resource"]["google_bigquery_dataset"]).to include(
+        name => expected_dataset
+      )
+    end
+
+    it "includes dimensions table configuration" do
+      expect(json["resource"]["google_bigquery_table"]).to include(
+        "dimensions" => expected_dimensions_table
+      )
+    end
+
+    def expected_dataset
+      {
+        "dataset_id" => name,
+        "project" => "${var.project_id}",
+        "location" => "US"
+      }
+    end
+
+    def expected_dimensions_table
+      {
+        "dataset_id" => name,
+        "project" => "${var.project_id}",
+        "table_id" => "dimensions",
+        "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
+        "depends_on" => ["google_bigquery_dataset.#{name}"]
+      }
+    end
+  end
+end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
   describe "#as_json" do
     subject(:json) { config.as_json }
 
-    it "includes PROJECT_ID variable" do
-      expect(json["variable"]["PROJECT_ID"]).to include(
+    it "includes project_id variable" do
+      expect(json["variable"]["project_id"]).to include(
         "description" => "The GCP project ID where resources will be created",
         "type" => "string"
       )
@@ -32,7 +32,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
     def expected_dataset
       {
         "dataset_id" => name,
-        "project" => "${var.PROJECT_ID}",
+        "project" => "${var.project_id}",
         "location" => "US"
       }
     end
@@ -40,7 +40,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
     def expected_dimensions_table
       {
         "dataset_id" => name,
-        "project" => "${var.PROJECT_ID}",
+        "project" => "${var.project_id}",
         "table_id" => "dimensions",
         "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
         "depends_on" => ["google_bigquery_dataset.#{name}"]

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
       {
         "dataset_id" => name,
         "project" => "${var.project_id}",
-        "table_id" => "dimensions",
+        "table_id" => "Dimensions",
         "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
         "depends_on" => ["google_bigquery_dataset.#{name}"]
       }


### PR DESCRIPTION
Scaffolds terraform generation as part of the `manifold generate` command. We generate an entrypoint at the top of the project, and we reference all workspaces in the project as modules.

We use [JSON Configuration Syntax](https://developer.hashicorp.com/terraform/language/syntax/json) since that's a little bit easier to generate from Ruby.

Currently, terraform generation is feature flagged. You can opt in with the `--tf` flag by running `manifold generate --tf`.