### PR TITLE
Generate Dimensions Merges

### DIFF
--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -56,6 +56,10 @@ module Manifold
         directory.join("manifold.yml")
       end
 
+      def terraform_main_path
+        directory.join("main.tf.json")
+      end
+
       private
 
       def directory
@@ -103,11 +107,11 @@ module Manifold
 
       def generate_terraform
         config = Terraform::WorkspaceConfiguration.new(name)
+        vectors.each do |vector|
+          vector_config = @vector_service.load_vector_config(vector)
+          config.add_vector(vector_config)
+        end
         config.write(terraform_main_path)
-      end
-
-      def terraform_main_path
-        directory.join("main.tf.json")
       end
     end
   end

--- a/lib/manifold/services/vector_service.rb
+++ b/lib/manifold/services/vector_service.rb
@@ -19,6 +19,16 @@ module Manifold
         raise "Invalid YAML in vector configuration #{path}: #{e.message}"
       end
 
+      def load_vector_config(vector_name)
+        path = config_path(vector_name)
+        config = YAML.safe_load_file(path)
+        config.merge("name" => vector_name.downcase)
+      rescue Errno::ENOENT, Errno::EISDIR
+        raise "Vector configuration not found: #{path}"
+      rescue Psych::Exception => e
+        raise "Invalid YAML in vector configuration #{path}: #{e.message}"
+      end
+
       private
 
       def transform_attributes_to_schema(attributes)

--- a/lib/manifold/templates/vector_template.yml
+++ b/lib/manifold/templates/vector_template.yml
@@ -6,5 +6,6 @@ attributes:
   # created_at: TIMESTAMP
   # status: STRING
 
-merge:
-  source: lib/routines/select_my_vector.sql
+# Optionally, specify how to select vector dimensions
+# merge:
+#   source: lib/routines/select_my_vector.sql

--- a/lib/manifold/templates/vector_template.yml
+++ b/lib/manifold/templates/vector_template.yml
@@ -6,6 +6,6 @@ attributes:
   # created_at: TIMESTAMP
   # status: STRING
 
-# Optionally, specify how to select vector dimensions
+# Optionally, reference a view specifying how to select vector dimensions
 # merge:
-#   source: lib/routines/select_my_vector.sql
+#   source: lib/views/select_my_vector.sql

--- a/lib/manifold/templates/vector_template.yml
+++ b/lib/manifold/templates/vector_template.yml
@@ -5,3 +5,6 @@ attributes:
   # id: STRING
   # created_at: TIMESTAMP
   # status: STRING
+
+merge:
+  source: lib/routines/select_my_vector.sql

--- a/spec/manifold/services/vector_service_spec.rb
+++ b/spec/manifold/services/vector_service_spec.rb
@@ -72,4 +72,61 @@ RSpec.describe Manifold::Services::VectorService do
       end
     end
   end
+
+  describe "#load_vector_config" do
+    let(:vector_name) { "page" }
+    let(:vector_config) do
+      {
+        "attributes" => {
+          "url" => "string",
+          "title" => "string"
+        },
+        "merge" => {
+          "source" => "lib/routines/select_pages.sql"
+        }
+      }
+    end
+
+    let(:expected_config) do
+      vector_config.merge("name" => vector_name)
+    end
+
+    context "when vector configuration exists" do
+      before do
+        Pathname.pwd.join("vectors").mkpath
+        config_path = Pathname.pwd.join("vectors", "#{vector_name}.yml")
+        config_path.write(YAML.dump(vector_config))
+      end
+
+      it "loads the complete vector configuration" do
+        expect(service.load_vector_config(vector_name)).to eq(expected_config)
+      end
+
+      it "handles uppercase vector names" do
+        expect(service.load_vector_config(vector_name.upcase)).to eq(expected_config)
+      end
+    end
+
+    context "when vector configuration doesn't exist" do
+      it "raises an error" do
+        expect { service.load_vector_config(vector_name) }.to raise_error(
+          "Vector configuration not found: #{Pathname.pwd.join("vectors", "#{vector_name}.yml")}"
+        )
+      end
+    end
+
+    context "when vector configuration is invalid" do
+      before do
+        Pathname.pwd.join("vectors").mkpath
+        config_path = Pathname.pwd.join("vectors", "#{vector_name}.yml")
+        config_path.write("invalid_key: [value1, value2")
+      end
+
+      it "raises an error" do
+        expect { service.load_vector_config(vector_name) }.to raise_error(
+          /Invalid YAML in vector configuration/
+        )
+      end
+    end
+  end
 end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -31,64 +31,21 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
 
     context "when vectors have merge configurations" do
       let(:source_sql) { "SELECT id, STRUCT(url, title) AS dimensions FROM pages" }
-      let(:vector_config) do
-        {
-          "name" => "Page",
-          "attributes" => {
-            "url" => "string",
-            "title" => "string"
-          },
-          "merge" => {
-            "source" => "lib/routines/select_pages.sql"
-          }
-        }
-      end
 
       before do
-        Pathname.pwd.join("lib/routines").mkpath
-        Pathname.pwd.join("lib/routines/select_pages.sql").write(source_sql)
+        setup_merge_vector_config
         config.add_vector(vector_config)
       end
 
       it "includes routine configuration" do
         expect(json["resource"]["google_bigquery_routine"]).to include(
-          "merge_page_dimensions" => {
-            "dataset_id" => name,
-            "project" => "${var.project_id}",
-            "routine_id" => "merge_page_dimensions",
-            "routine_type" => "PROCEDURE",
-            "language" => "SQL",
-            "definition_body" => expected_merge_routine,
-            "depends_on" => ["google_bigquery_dataset.#{name}"]
-          }
+          "merge_page_dimensions" => expected_routine_config
         )
-      end
-
-      def expected_merge_routine
-        <<~SQL
-          MERGE #{name}.Dimensions AS TARGET
-          USING (
-            #{source_sql}
-          ) AS source
-          ON source.id = target.id
-          WHEN MATCHED THEN UPDATE SET target.page = source.dimensions
-          WHEN NOT MATCHED THEN INSERT ROW;
-        SQL
       end
     end
 
     context "when vectors have no merge configurations" do
-      let(:vector_config) do
-        {
-          "name" => "Page",
-          "attributes" => {
-            "url" => "string",
-            "title" => "string"
-          }
-        }
-      end
-
-      before { config.add_vector(vector_config) }
+      before { config.add_vector(vector_config_without_merge) }
 
       it "excludes routine configuration" do
         expect(json["resource"]["google_bigquery_routine"]).to be_nil
@@ -111,6 +68,52 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
         "depends_on" => ["google_bigquery_dataset.#{name}"]
       }
+    end
+
+    def expected_routine_config
+      {
+        "dataset_id" => name,
+        "project" => "${var.project_id}",
+        "routine_id" => "merge_page_dimensions",
+        "routine_type" => "PROCEDURE",
+        "language" => "SQL",
+        "definition_body" => expected_merge_routine,
+        "depends_on" => ["google_bigquery_dataset.#{name}"]
+      }
+    end
+
+    def expected_merge_routine
+      <<~SQL
+        MERGE #{name}.Dimensions AS TARGET
+        USING (
+          #{source_sql}
+        ) AS source
+        ON source.id = target.id
+        WHEN MATCHED THEN UPDATE SET target.page = source.dimensions
+        WHEN NOT MATCHED THEN INSERT ROW;
+      SQL
+    end
+
+    def setup_merge_vector_config
+      Pathname.pwd.join("lib/routines").mkpath
+      Pathname.pwd.join("lib/routines/select_pages.sql").write(source_sql)
+    end
+
+    def vector_config
+      {
+        "name" => "Page",
+        "attributes" => {
+          "url" => "string",
+          "title" => "string"
+        },
+        "merge" => {
+          "source" => "lib/routines/select_pages.sql"
+        }
+      }
+    end
+
+    def vector_config_without_merge
+      vector_config.tap { |config| config.delete("merge") }
     end
   end
 end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -29,6 +29,72 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
       )
     end
 
+    context "when vectors have merge configurations" do
+      let(:source_sql) { "SELECT id, STRUCT(url, title) AS dimensions FROM pages" }
+      let(:vector_config) do
+        {
+          "name" => "Page",
+          "attributes" => {
+            "url" => "string",
+            "title" => "string"
+          },
+          "merge" => {
+            "source" => "lib/routines/select_pages.sql"
+          }
+        }
+      end
+
+      before do
+        Pathname.pwd.join("lib/routines").mkpath
+        Pathname.pwd.join("lib/routines/select_pages.sql").write(source_sql)
+        config.add_vector(vector_config)
+      end
+
+      it "includes routine configuration" do
+        expect(json["resource"]["google_bigquery_routine"]).to include(
+          "merge_page_dimensions" => {
+            "dataset_id" => name,
+            "project" => "${var.project_id}",
+            "routine_id" => "merge_page_dimensions",
+            "routine_type" => "PROCEDURE",
+            "language" => "SQL",
+            "definition_body" => expected_merge_routine,
+            "depends_on" => ["google_bigquery_dataset.#{name}"]
+          }
+        )
+      end
+
+      def expected_merge_routine
+        <<~SQL
+          MERGE #{name}.Dimensions AS TARGET
+          USING (
+            #{source_sql}
+          ) AS source
+          ON source.id = target.id
+          WHEN MATCHED THEN UPDATE SET target.page = source.dimensions
+          WHEN NOT MATCHED THEN INSERT ROW;
+        SQL
+      end
+    end
+
+    context "when vectors have no merge configurations" do
+      let(:vector_config) do
+        {
+          "name" => "Page",
+          "attributes" => {
+            "url" => "string",
+            "title" => "string"
+          }
+        }
+      end
+
+      before { config.add_vector(vector_config) }
+
+      it "excludes routine configuration" do
+        expect(json["resource"]["google_bigquery_routine"]).to be_nil
+      end
+    end
+
     def expected_dataset
       {
         "dataset_id" => name,


### PR DESCRIPTION
Adds support for automatically generating BigQuery merge routines that update vector dimensions in a manifold's dimensions table. This enables users to define the source SQL for their vector dimensions and have the appropriate merge routine automatically generated and managed via Terraform.

## Changes

### Vector Configuration
- Added optional `merge` configuration to vector YAML files:
  ```yaml
  attributes:
    url: string
    title: string
  
  merge:
    source: lib/routines/select_my_vector.sql
  ```
- The `source` field specifies the path to a SQL file that selects the vector's dimensions

### Terraform Generation
- Added support for generating `google_bigquery_routine` resources for vectors with merge configurations
- Each routine is named `merge_<vector_name>_dimensions` and follows this pattern:
  ```sql
  MERGE dataset.Dimensions AS TARGET
  USING (
    -- User's source SQL here
  ) AS source
  ON source.id = target.id
  WHEN MATCHED THEN UPDATE SET target.vector_name = source.dimensions
  WHEN NOT MATCHED THEN INSERT ROW;
  ```