### PR TITLE
Vector Field Modes

### DIFF
--- a/lib/manifold/services/vector_service.rb
+++ b/lib/manifold/services/vector_service.rb
@@ -32,13 +32,20 @@ module Manifold
       private
 
       def transform_attributes_to_schema(attributes)
-        attributes.map do |name, type|
+        attributes.map do |name, type_str|
+          type, mode = parse_type_and_mode(type_str)
           {
             "name" => name,
             "type" => type.upcase,
-            "mode" => "NULLABLE"
+            "mode" => mode
           }
         end
+      end
+
+      def parse_type_and_mode(type_str)
+        type, mode = type_str.split(":")
+        mode = mode&.upcase || "NULLABLE"
+        [type, mode]
       end
 
       def config_path(vector_name)

--- a/lib/manifold/templates/vector_template.yml
+++ b/lib/manifold/templates/vector_template.yml
@@ -5,6 +5,7 @@ attributes:
   # id: STRING
   # created_at: TIMESTAMP
   # status: STRING
+  # names: STRING:REPEATED
 
 # Optionally, reference a view specifying how to select vector dimensions
 # merge:

--- a/spec/manifold/services/vector_service_spec.rb
+++ b/spec/manifold/services/vector_service_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Manifold::Services::VectorService do
         "attributes" => {
           "id" => "string",
           "url" => "string",
-          "created_at" => "timestamp"
+          "created_at" => "timestamp",
+          "tags" => "string:repeated",
+          "email" => "string:required"
         }
       }
     end
@@ -25,7 +27,9 @@ RSpec.describe Manifold::Services::VectorService do
         "fields" => [
           { "name" => "id", "type" => "STRING", "mode" => "NULLABLE" },
           { "name" => "url", "type" => "STRING", "mode" => "NULLABLE" },
-          { "name" => "created_at", "type" => "TIMESTAMP", "mode" => "NULLABLE" }
+          { "name" => "created_at", "type" => "TIMESTAMP", "mode" => "NULLABLE" },
+          { "name" => "tags", "type" => "STRING", "mode" => "REPEATED" },
+          { "name" => "email", "type" => "STRING", "mode" => "REQUIRED" }
         ]
       }
     end


### PR DESCRIPTION
This change enables users to specify BigQuery field modes (REPEATED, REQUIRED) in their vector configurations using a simple type suffix syntax. Fields without an explicit mode remain NULLABLE by default.

## Changes
- Modified `VectorService#transform_attributes_to_schema` to parse field modes from type definitions
- Added `VectorService#parse_type_and_mode` helper method to handle the type:mode syntax
- Updated tests to verify handling of all field modes

## Usage
Users can now specify field modes in their vector configurations using the following syntax:

```yaml
attributes:
# Standard NULLABLE field (default)
url: STRING

# REPEATED field for array-like data
tags: STRING:REPEATED

# REQUIRED field for non-null data
email: STRING:REQUIRED
```