### PR TITLE
Record Fields

### DIFF
--- a/lib/manifold/services/vector_service.rb
+++ b/lib/manifold/services/vector_service.rb
@@ -32,14 +32,33 @@ module Manifold
       private
 
       def transform_attributes_to_schema(attributes)
-        attributes.map do |name, type_str|
-          type, mode = parse_type_and_mode(type_str)
-          {
-            "name" => name,
-            "type" => type.upcase,
-            "mode" => mode
-          }
+        attributes.map { |name, type_def| transform_field(name, type_def) }
+      end
+
+      def transform_field(name, type_def)
+        if type_def.is_a?(Hash)
+          transform_record_field(name, type_def)
+        else
+          transform_scalar_field(name, type_def)
         end
+      end
+
+      def transform_record_field(name, type_def)
+        {
+          "name" => name,
+          "type" => "RECORD",
+          "mode" => "NULLABLE",
+          "fields" => transform_attributes_to_schema(type_def)
+        }
+      end
+
+      def transform_scalar_field(name, type_def)
+        type, mode = parse_type_and_mode(type_def)
+        {
+          "name" => name,
+          "type" => type.upcase,
+          "mode" => mode
+        }
       end
 
       def parse_type_and_mode(type_str)

--- a/lib/manifold/templates/vector_template.yml
+++ b/lib/manifold/templates/vector_template.yml
@@ -6,6 +6,9 @@ attributes:
   # created_at: TIMESTAMP
   # status: STRING
   # names: STRING:REPEATED
+  # key_values:
+  #   first_key: STRING
+  #   second_key: STRING:REQUIRED
 
 # Optionally, reference a view specifying how to select vector dimensions
 # merge:

--- a/lib/manifold/version.rb
+++ b/lib/manifold/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Manifold
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end

--- a/spec/manifold/services/vector_service_spec.rb
+++ b/spec/manifold/services/vector_service_spec.rb
@@ -15,7 +15,19 @@ RSpec.describe Manifold::Services::VectorService do
           "url" => "string",
           "created_at" => "timestamp",
           "tags" => "string:repeated",
-          "email" => "string:required"
+          "email" => "string:required",
+          "metadata" => {
+            "source" => "string",
+            "last_modified" => "timestamp",
+            "settings" => {
+              "enabled" => "boolean",
+              "flags" => "string:repeated"
+            }
+          },
+          "key_values" => {
+            "first_key" => "string",
+            "second_key" => "string:required"
+          }
         }
       }
     end
@@ -29,7 +41,34 @@ RSpec.describe Manifold::Services::VectorService do
           { "name" => "url", "type" => "STRING", "mode" => "NULLABLE" },
           { "name" => "created_at", "type" => "TIMESTAMP", "mode" => "NULLABLE" },
           { "name" => "tags", "type" => "STRING", "mode" => "REPEATED" },
-          { "name" => "email", "type" => "STRING", "mode" => "REQUIRED" }
+          { "name" => "email", "type" => "STRING", "mode" => "REQUIRED" },
+          {
+            "name" => "metadata",
+            "type" => "RECORD",
+            "mode" => "NULLABLE",
+            "fields" => [
+              { "name" => "source", "type" => "STRING", "mode" => "NULLABLE" },
+              { "name" => "last_modified", "type" => "TIMESTAMP", "mode" => "NULLABLE" },
+              {
+                "name" => "settings",
+                "type" => "RECORD",
+                "mode" => "NULLABLE",
+                "fields" => [
+                  { "name" => "enabled", "type" => "BOOLEAN", "mode" => "NULLABLE" },
+                  { "name" => "flags", "type" => "STRING", "mode" => "REPEATED" }
+                ]
+              }
+            ]
+          },
+          {
+            "name" => "key_values",
+            "type" => "RECORD",
+            "mode" => "NULLABLE",
+            "fields" => [
+              { "name" => "first_key", "type" => "STRING", "mode" => "NULLABLE" },
+              { "name" => "second_key", "type" => "STRING", "mode" => "REQUIRED" }
+            ]
+          }
         ]
       }
     end


### PR DESCRIPTION
This change enables users to specify RECORD fields in vector yaml:

```yaml
attributes:
  # Standard scalar fields with modes
  id: STRING # NULLABLE by default
  tags: STRING:REPEATED # Array of strings
  email: STRING:REQUIRED # Non-null field
  
  # Nested RECORD fields
  metadata:
    source: STRING
    settings:
      enabled: BOOLEAN
      flags: STRING:REPEATED
```