### PR TITLE
Generate Manifold

### DIFF
--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -33,7 +33,7 @@ module Manifold
       def metrics_fields
         return [] unless @manifold_yaml["contexts"] && @manifold_yaml["metrics"]
 
-        @manifold_yaml["contexts"].map do |context_name, _|
+        @manifold_yaml["contexts"].map do |context_name, _context_config|
           {
             "name" => context_name,
             "type" => "RECORD",

--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -4,6 +4,8 @@ module Manifold
   module API
     # Handles schema generation for Manifold tables
     class SchemaGenerator
+      VALID_OPERATORS = %w[AND OR NOT NAND NOR XOR XNOR].freeze
+
       def initialize(dimensions_fields, manifold_yaml)
         @dimensions_fields = dimensions_fields
         @manifold_yaml = manifold_yaml
@@ -70,6 +72,12 @@ module Manifold
             "mode" => "NULLABLE"
           }
         end
+      end
+
+      def validate_operator!(operator)
+        return if VALID_OPERATORS.include?(operator)
+
+        raise ArgumentError, "Invalid operator: #{operator}. Valid operators are: #{VALID_OPERATORS.join(", ")}"
       end
     end
   end

--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Manifold
+  module API
+    # Handles schema generation for Manifold tables
+    class SchemaGenerator
+      def initialize(dimensions_fields, manifold_yaml)
+        @dimensions_fields = dimensions_fields
+        @manifold_yaml = manifold_yaml
+      end
+
+      def dimensions_schema
+        [
+          { "type" => "STRING", "name" => "id", "mode" => "REQUIRED" },
+          { "type" => "RECORD", "name" => "dimensions", "mode" => "REQUIRED",
+            "fields" => @dimensions_fields }
+        ]
+      end
+
+      def manifold_schema
+        [
+          { "type" => "STRING", "name" => "id", "mode" => "REQUIRED" },
+          { "type" => "TIMESTAMP", "name" => "timestamp", "mode" => "REQUIRED" },
+          { "type" => "RECORD", "name" => "dimensions", "mode" => "REQUIRED",
+            "fields" => @dimensions_fields },
+          { "type" => "RECORD", "name" => "metrics", "mode" => "REQUIRED",
+            "fields" => metrics_fields }
+        ]
+      end
+
+      private
+
+      def metrics_fields
+        return [] unless @manifold_yaml["contexts"] && @manifold_yaml["metrics"]
+
+        @manifold_yaml["contexts"].map do |context_name, _|
+          {
+            "name" => context_name,
+            "type" => "RECORD",
+            "mode" => "NULLABLE",
+            "fields" => context_metrics_fields
+          }
+        end
+      end
+
+      def context_metrics_fields
+        [
+          *countif_fields,
+          *sumif_fields
+        ]
+      end
+
+      def countif_fields
+        return [] unless @manifold_yaml.dig("metrics", "countif")
+
+        [{
+          "name" => @manifold_yaml["metrics"]["countif"],
+          "type" => "INTEGER",
+          "mode" => "NULLABLE"
+        }]
+      end
+
+      def sumif_fields
+        return [] unless @manifold_yaml.dig("metrics", "sumif")
+
+        @manifold_yaml["metrics"]["sumif"].keys.map do |metric_name|
+          {
+            "name" => metric_name,
+            "type" => "INTEGER",
+            "mode" => "NULLABLE"
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -8,23 +8,19 @@ dimensions:
   merge:
     source: lib/views/select_my_vector.sql
 
+timestamp:
+  interval: HOUR
+  field: timestamp
+
+contexts:
+  paid: IS_PAID(context.location)
+  organic: IS_ORGANIC(context.location)
+
 metrics:
-  - name: # Add your metric name here, e.g. Pageviews
+  countif: tapCount
+  sumif:
+    sequenceSum:
+      field: context.sequence
 
-    id:
-      field: # Identify the field that uniquely identifies each manifold vector
-      type: # Specify the type of that field, e.g. INTEGER
-
-    interval:
-      type: # Specify the interval type, e.g. TIMESTAMP or DATE
-      expression: # Compute the interval for the entry, e.g. TIMESTAMP_TRUNC(timestamp, HOUR)
-
-    aggregations:
-      # Add any aggregations this metric should present
-
-    source:
-      type: BIGQUERY_TABLE
-      project: # Add your project name here
-      dataset: # Add your dataset name here
-      table: # Add your table name
-      filter: # (optional) Add your filter condition here
+source: my_project.my_dataset.my_table
+filter: timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -15,6 +15,11 @@ timestamp:
 contexts:
   paid: IS_PAID(context.location)
   organic: IS_ORGANIC(context.location)
+  paidOrganic:
+    fields:
+      - paid
+      - organic
+    operator: AND
 
 metrics:
   countif: tapCount

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -53,13 +53,28 @@ module Manifold
 
       def table_config
         {
-          "dimensions" => {
-            "dataset_id" => name,
-            "project" => "${var.project_id}",
-            "table_id" => "Dimensions",
-            "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
-            "depends_on" => ["google_bigquery_dataset.#{name}"]
-          }
+          "dimensions" => dimensions_table_config,
+          "manifold" => manifold_table_config
+        }
+      end
+
+      def dimensions_table_config
+        {
+          "dataset_id" => name,
+          "project" => "${var.project_id}",
+          "table_id" => "Dimensions",
+          "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
+          "depends_on" => ["google_bigquery_dataset.#{name}"]
+        }
+      end
+
+      def manifold_table_config
+        {
+          "dataset_id" => name,
+          "project" => "${var.project_id}",
+          "table_id" => "Manifold",
+          "schema" => "${file(\"${path.module}/tables/manifold.json\")}",
+          "depends_on" => ["google_bigquery_dataset.#{name}"]
         }
       end
 

--- a/lib/manifold/version.rb
+++ b/lib/manifold/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Manifold
-  VERSION = "0.0.14"
+  VERSION = "0.0.15"
 end

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -83,6 +83,11 @@ RSpec.describe Manifold::API::Workspace do
           contexts:
             paid: IS_PAID(context.location)
             organic: IS_ORGANIC(context.location)
+            paidOrganic:
+              fields:
+                - paid
+                - organic
+              operator: AND
           metrics:
             countif: tapCount
             sumif:
@@ -157,6 +162,12 @@ RSpec.describe Manifold::API::Workspace do
 
       include_examples "context metrics", "paid"
       include_examples "context metrics", "organic"
+      include_examples "context metrics", "paidOrganic"
+
+      it "includes all contexts in the metrics fields" do
+        context_names = schema_fields[:metrics]["fields"].map { |f| f["name"] }
+        expect(context_names).to contain_exactly("paid", "organic", "paidOrganic")
+      end
 
       it "logs vector schema loading" do
         expect(logger).to have_received(:info).with("Loading vector schema for 'User'.")

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -88,6 +88,35 @@ RSpec.describe Manifold::API::Workspace do
                 - paid
                 - organic
               operator: AND
+            paidOrOrganic:
+              fields:
+                - paid
+                - organic
+              operator: OR
+            notPaid:
+              fields:
+                - paid
+              operator: NOT
+            neitherPaidNorOrganic:
+              fields:
+                - paid
+                - organic
+              operator: NOR
+            notBothPaidAndOrganic:
+              fields:
+                - paid
+                - organic
+              operator: NAND
+            eitherPaidOrOrganic:
+              fields:
+                - paid
+                - organic
+              operator: XOR
+            similarPaidOrganic:
+              fields:
+                - paid
+                - organic
+              operator: XNOR
           metrics:
             countif: tapCount
             sumif:
@@ -163,10 +192,24 @@ RSpec.describe Manifold::API::Workspace do
       include_examples "context metrics", "paid"
       include_examples "context metrics", "organic"
       include_examples "context metrics", "paidOrganic"
+      include_examples "context metrics", "paidOrOrganic"
+      include_examples "context metrics", "notPaid"
+      include_examples "context metrics", "neitherPaidNorOrganic"
+      include_examples "context metrics", "notBothPaidAndOrganic"
+      include_examples "context metrics", "eitherPaidOrOrganic"
+      include_examples "context metrics", "similarPaidOrganic"
 
       it "includes all contexts in the metrics fields" do
-        context_names = schema_fields[:metrics]["fields"].map { |f| f["name"] }
-        expect(context_names).to contain_exactly("paid", "organic", "paidOrganic")
+        expect(schema_fields[:metrics]["fields"].map { |f| f["name"] })
+          .to match_array(expected_context_names)
+      end
+
+      def expected_context_names
+        %w[
+          paid organic paidOrganic paidOrOrganic notPaid
+          neitherPaidNorOrganic notBothPaidAndOrganic
+          eitherPaidOrOrganic similarPaidOrganic
+        ]
       end
 
       it "logs vector schema loading" do

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
       )
     end
 
+    it "includes manifold table configuration" do
+      expect(json["resource"]["google_bigquery_table"]).to include(
+        "manifold" => expected_manifold_table
+      )
+    end
+
     context "when vectors have merge configurations" do
       let(:source_sql) { "SELECT id, STRUCT(url, title) AS dimensions FROM pages" }
 
@@ -67,6 +73,16 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         "project" => "${var.project_id}",
         "table_id" => "Dimensions",
         "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
+        "depends_on" => ["google_bigquery_dataset.#{name}"]
+      }
+    end
+
+    def expected_manifold_table
+      {
+        "dataset_id" => name,
+        "project" => "${var.project_id}",
+        "table_id" => "Manifold",
+        "schema" => "${file(\"${path.module}/tables/manifold.json\")}",
         "depends_on" => ["google_bigquery_dataset.#{name}"]
       }
     end


### PR DESCRIPTION
Enables generating manifold configurations, including the ability to configure both simple and composite metrics contexts.

## Changes

- Added support for composite contexts in the schema generator
- Each composite context maintains the same metric structure as base contexts
- Contexts can be combined using logical operators (currently supporting AND)

## Example Usage

Users can now define composite contexts in their `manifold.yml`:

```yaml
contexts:
  total: TRUE
  paid: IS_PAID(context.location)
  organic: IS_ORGANIC(context.location)
  paidOrganic:
    fields:
      - paid
      - organic
    operator: AND
```

This will generate a schema with three context structs (paid, organic, and paidOrganic), each containing the same metric fields. For example, with the following metrics configuration:

```yaml
metrics:
  countif: tapCount
  sumif:
    sequenceSum:
      field: context.sequence
```

the following schema manifold metrics schema will be produced:

```json
{
    "type": "RECORD",
    "name": "metrics",
    "mode": "REQUIRED",
    "fields": [
      {
        "name": "total",
        "type": "RECORD",
        "mode": "NULLABLE",
        "fields": [
          {
            "name": "tapCount",
            "type": "INTEGER",
            "mode": "NULLABLE"
          },
          {
            "name": "sequenceSum",
            "type": "INTEGER",
            "mode": "NULLABLE"
          }
        ]
      },
      {
        "name": "paid",
        "type": "RECORD",
        "mode": "NULLABLE",
        "fields": [
          {
            "name": "tapCount",
            "type": "INTEGER",
            "mode": "NULLABLE"
          },
          {
            "name": "sequenceSum",
            "type": "INTEGER",
            "mode": "NULLABLE"
          }
        ]
      },
      {
        "name": "organic",
        "type": "RECORD",
        "mode": "NULLABLE",
        "fields": [
          {
            "name": "tapCount",
            "type": "INTEGER",
            "mode": "NULLABLE"
          },
          {
            "name": "sequenceSum",
            "type": "INTEGER",
            "mode": "NULLABLE"
          }
        ]
      },
      {
        "name": "paidOrganic",
        "type": "RECORD",
        "mode": "NULLABLE",
        "fields": [
          {
            "name": "tapCount",
            "type": "INTEGER",
            "mode": "NULLABLE"
          },
          {
            "name": "sequenceSum",
            "type": "INTEGER",
            "mode": "NULLABLE"
          }
        ]
      }
    ]
  }
```