### PR TITLE
Generate Manifold Merge

### DIFF
--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -4,6 +4,8 @@ module Manifold
   module API
     # Handles terraform configuration generation
     class TerraformGenerator
+      attr_accessor :manifold_config
+
       def initialize(name, vectors, vector_service, manifold_yaml)
         @name = name
         @vectors = vectors
@@ -18,6 +20,7 @@ module Manifold
           config.add_vector(vector_config)
         end
         config.merge_config = @manifold_yaml["dimensions"]&.fetch("merge", nil) if @manifold_yaml["dimensions"]
+        config.manifold_config = @manifold_yaml
         config.write(path)
       end
     end
@@ -145,6 +148,7 @@ module Manifold
 
       def generate_terraform
         terraform_generator = TerraformGenerator.new(name, vectors, @vector_service, manifold_yaml)
+        terraform_generator.manifold_config = manifold_yaml
         terraform_generator.generate(terraform_main_path)
       end
 

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -2,9 +2,224 @@
 
 module Manifold
   module Terraform
+    # Handles building metrics SQL for manifold routines
+    class MetricsBuilder
+      def initialize(manifold_config)
+        @manifold_config = manifold_config
+      end
+
+      def build_metrics_struct
+        return "" unless @manifold_config&.dig("contexts") && @manifold_config&.dig("metrics")
+
+        context_structs = @manifold_config["contexts"].map do |name, config|
+          condition = build_context_condition(name, config)
+          metrics = build_context_metrics(condition)
+          "STRUCT(#{metrics}) AS #{name}"
+        end
+
+        context_structs.join(",\n")
+      end
+
+      private
+
+      def build_context_metrics(condition)
+        metrics = []
+        add_count_metrics(metrics, condition)
+        add_sum_metrics(metrics, condition)
+        metrics.join(",\n")
+      end
+
+      def add_count_metrics(metrics, condition)
+        return unless @manifold_config.dig("metrics", "countif")
+
+        metrics << "COUNTIF(#{condition}) AS #{@manifold_config["metrics"]["countif"]}"
+      end
+
+      def add_sum_metrics(metrics, condition)
+        @manifold_config.dig("metrics", "sumif")&.each do |name, config|
+          metrics << "SUM(IF(#{condition}, #{config["field"]}, 0)) AS #{name}"
+        end
+      end
+
+      def build_context_condition(_name, config)
+        return config unless config.is_a?(Hash)
+
+        operator = config["operator"]
+        fields = config["fields"]
+        build_operator_condition(operator, fields)
+      end
+
+      def build_operator_condition(operator, fields)
+        conditions = fields.map { |f| @manifold_config["contexts"][f] }
+        case operator
+        when "AND", "OR" then join_conditions(conditions, operator)
+        when "NOT" then negate_condition(conditions.first)
+        when "NAND", "NOR" then negate_joined_conditions(conditions, operator[1..])
+        when "XOR" then build_xor_condition(conditions)
+        when "XNOR" then build_xnor_condition(conditions)
+        else config
+        end
+      end
+
+      def join_conditions(conditions, operator)
+        conditions.join(" #{operator} ")
+      end
+
+      def negate_condition(condition)
+        "NOT (#{condition})"
+      end
+
+      def negate_joined_conditions(conditions, operator)
+        "NOT (#{join_conditions(conditions, operator)})"
+      end
+
+      def build_xor_condition(conditions)
+        "(#{conditions[0]} AND NOT #{conditions[1]}) OR (NOT #{conditions[0]} AND #{conditions[1]})"
+      end
+
+      def build_xnor_condition(conditions)
+        "(#{conditions[0]} AND #{conditions[1]}) OR (NOT #{conditions[0]} AND NOT #{conditions[1]})"
+      end
+    end
+
+    # Handles building SQL for manifold routines
+    class SQLBuilder
+      def initialize(name, manifold_config)
+        @name = name
+        @manifold_config = manifold_config
+      end
+
+      def build_manifold_merge_sql(_metrics_builder, &)
+        return "" unless valid_config?
+
+        <<~SQL
+          MERGE #{@name}.Manifold AS target USING (
+            #{build_metrics_cte(&)}
+            #{build_final_select}
+          ) AS source#{" "}
+          ON source.id = target.id AND source.timestamp = target.timestamp
+          #{build_merge_actions}
+        SQL
+      end
+
+      def build_dimensions_merge_sql(source_sql)
+        <<~SQL
+          MERGE #{@name}.Dimensions AS TARGET
+          USING (
+            #{source_sql}
+          ) AS source
+          ON source.id = target.id
+          WHEN MATCHED THEN UPDATE SET target.dimensions = source.dimensions
+          WHEN NOT MATCHED THEN INSERT ROW;
+        SQL
+      end
+
+      private
+
+      def valid_config?
+        source_table && timestamp_field
+      end
+
+      def build_metrics_cte(&)
+        <<~SQL
+          WITH Metrics AS (
+            #{build_metrics_select(&)}
+          )
+        SQL
+      end
+
+      def build_metrics_select(&block)
+        <<~SQL
+          SELECT
+            dimensions.#{id_field} id,
+            TIMESTAMP_TRUNC(#{timestamp_field}, #{interval}) timestamp,
+            STRUCT(
+              #{block.call}
+            ) AS metrics
+          FROM `#{source_table}`
+          WHERE #{timestamp_field} >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL #{lookback})
+          GROUP BY 1, 2
+        SQL
+      end
+
+      def build_final_select
+        <<~SQL
+          SELECT id, timestamp, #{@name}.Dimensions.dimensions, Metrics.metrics#{" "}
+          FROM Metrics#{" "}
+          LEFT JOIN #{@name}.Dimensions USING (id)
+        SQL
+      end
+
+      def build_merge_actions
+        <<~SQL
+          WHEN MATCHED THEN
+            UPDATE SET
+              metrics = source.metrics,
+              dimensions = source.dimensions
+          WHEN NOT MATCHED THEN
+            INSERT ROW;
+        SQL
+      end
+
+      def source_table
+        @manifold_config&.dig("source", "table")
+      end
+
+      def interval
+        @manifold_config&.dig("timestamp", "interval") || "DAY"
+      end
+
+      def lookback
+        @manifold_config&.dig("source", "lookback") || "90 DAY"
+      end
+
+      def id_field
+        @manifold_config&.dig("source", "id_field") || "id"
+      end
+
+      def timestamp_field
+        @manifold_config&.dig("timestamp", "field")
+      end
+    end
+
+    # Handles building table configurations
+    class TableConfigBuilder
+      def initialize(name)
+        @name = name
+      end
+
+      def build_table_configs
+        {
+          "dimensions" => dimensions_table_config,
+          "manifold" => manifold_table_config
+        }
+      end
+
+      private
+
+      def dimensions_table_config
+        build_table_config("Dimensions")
+      end
+
+      def manifold_table_config
+        build_table_config("Manifold")
+      end
+
+      def build_table_config(table_id)
+        {
+          "dataset_id" => @name,
+          "project" => "${var.project_id}",
+          "table_id" => table_id,
+          "schema" => "${file(\"${path.module}/tables/#{table_id.downcase}.json\")}",
+          "depends_on" => ["google_bigquery_dataset.#{@name}"]
+        }
+      end
+    end
+
     # Represents a Terraform configuration for a Manifold workspace.
     class WorkspaceConfiguration < Configuration
       attr_reader :name
+      attr_writer :merge_config, :manifold_config
 
       def initialize(name)
         super()
@@ -17,14 +232,12 @@ module Manifold
         @vectors << vector_config
       end
 
-      attr_writer :merge_config
-
       def as_json
         {
           "variable" => variables_block,
           "resource" => {
             "google_bigquery_dataset" => dataset_config,
-            "google_bigquery_table" => table_config,
+            "google_bigquery_table" => TableConfigBuilder.new(name).build_table_configs,
             "google_bigquery_routine" => routine_config
           }.compact
         }
@@ -51,68 +264,65 @@ module Manifold
         }
       end
 
-      def table_config
-        {
-          "dimensions" => dimensions_table_config,
-          "manifold" => manifold_table_config
-        }
-      end
-
-      def dimensions_table_config
-        {
-          "dataset_id" => name,
-          "project" => "${var.project_id}",
-          "table_id" => "Dimensions",
-          "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
-          "depends_on" => ["google_bigquery_dataset.#{name}"]
-        }
-      end
-
-      def manifold_table_config
-        {
-          "dataset_id" => name,
-          "project" => "${var.project_id}",
-          "table_id" => "Manifold",
-          "schema" => "${file(\"${path.module}/tables/manifold.json\")}",
-          "depends_on" => ["google_bigquery_dataset.#{name}"]
-        }
-      end
-
       def routine_config
+        routines = {
+          "merge_dimensions" => dimensions_routine_attributes,
+          "merge_manifold" => manifold_routine_attributes
+        }.compact
+
+        routines.empty? ? nil : routines
+      end
+
+      def dimensions_routine_attributes
         return nil if @vectors.empty? || @merge_config.nil?
 
-        {
-          "merge_dimensions" => routine_attributes
-        }
-      end
-
-      def routine_attributes
         {
           "dataset_id" => name,
           "project" => "${var.project_id}",
           "routine_id" => "merge_dimensions",
           "routine_type" => "PROCEDURE",
           "language" => "SQL",
-          "definition_body" => merge_routine_definition,
+          "definition_body" => dimensions_merge_routine,
           "depends_on" => ["google_bigquery_dataset.#{name}"]
         }
       end
 
-      def merge_routine_definition
-        source_sql = read_source_sql(@merge_config["source"])
-        <<~SQL
-          MERGE #{name}.Dimensions AS TARGET
-          USING (
-            #{source_sql}
-          ) AS source
-          ON source.id = target.id
-          WHEN MATCHED THEN UPDATE SET target.dimensions = source.dimensions
-          WHEN NOT MATCHED THEN INSERT ROW;
-        SQL
+      def dimensions_merge_routine
+        return "" if @vectors.empty? || @merge_config.nil?
+
+        source_sql = File.read(Pathname.pwd.join(@merge_config["source"]))
+        SQLBuilder.new(name, @manifold_config).build_dimensions_merge_sql(source_sql)
       end
 
-      def read_source_sql(source_path)
-        File.read(Pathname.pwd.join(source_path))
+      def manifold_routine_attributes
+        return nil unless valid_manifold_config?
+
+        {
+          "dataset_id" => name,
+          "project" => "${var.project_id}",
+          "routine_id" => "merge_manifold",
+          "routine_type" => "PROCEDURE",
+          "language" => "SQL",
+          "definition_body" => manifold_merge_routine,
+          "depends_on" => ["google_bigquery_dataset.#{name}"]
+        }
+      end
+
+      def manifold_merge_routine
+        metrics_builder = MetricsBuilder.new(@manifold_config)
+        sql_builder = SQLBuilder.new(name, @manifold_config)
+        sql_builder.build_manifold_merge_sql(metrics_builder) do
+          metrics_builder.build_metrics_struct
+        end
+      end
+
+      def valid_manifold_config?
+        return false unless @manifold_config
+
+        @manifold_config&.dig("source", "table") &&
+          @manifold_config&.dig("timestamp", "field") &&
+          @manifold_config&.dig("contexts") &&
+          @manifold_config&.dig("metrics")
       end
     end
   end

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -96,7 +96,7 @@ module Manifold
           MERGE #{@name}.Manifold AS target USING (
             #{build_metrics_cte(&)}
             #{build_final_select}
-          ) AS source#{" "}
+          ) AS source
           ON source.id = target.id AND source.timestamp = target.timestamp
           #{build_merge_actions}
         SQL
@@ -144,8 +144,8 @@ module Manifold
 
       def build_final_select
         <<~SQL
-          SELECT id, timestamp, #{@name}.Dimensions.dimensions, Metrics.metrics#{" "}
-          FROM Metrics#{" "}
+          SELECT id, timestamp, #{@name}.Dimensions.dimensions, Metrics.metrics
+          FROM Metrics
           LEFT JOIN #{@name}.Dimensions USING (id)
         SQL
       end

--- a/lib/manifold/version.rb
+++ b/lib/manifold/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Manifold
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 end

--- a/spec/manifold/terraform/metrics_builder_spec.rb
+++ b/spec/manifold/terraform/metrics_builder_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::Terraform::MetricsBuilder do
+  subject(:builder) { described_class.new(manifold_config) }
+
+  let(:manifold_config) do
+    {
+      "contexts" => {
+        "paid" => "IS_PAID(context.location)",
+        "organic" => "IS_ORGANIC(context.location)",
+        "paidOrganic" => {
+          "fields" => %w[paid organic],
+          "operator" => "AND"
+        },
+        "paidOrOrganic" => {
+          "fields" => %w[paid organic],
+          "operator" => "OR"
+        },
+        "notPaid" => {
+          "fields" => ["paid"],
+          "operator" => "NOT"
+        },
+        "neitherPaidNorOrganic" => {
+          "fields" => %w[paid organic],
+          "operator" => "NOR"
+        },
+        "notBothPaidAndOrganic" => {
+          "fields" => %w[paid organic],
+          "operator" => "NAND"
+        },
+        "eitherPaidOrOrganic" => {
+          "fields" => %w[paid organic],
+          "operator" => "XOR"
+        },
+        "similarPaidOrganic" => {
+          "fields" => %w[paid organic],
+          "operator" => "XNOR"
+        }
+      },
+      "metrics" => {
+        "countif" => "tapCount",
+        "sumif" => {
+          "sequenceSum" => {
+            "field" => "context.sequence"
+          }
+        }
+      }
+    }
+  end
+
+  describe "#build_metrics_struct" do
+    subject(:metrics_struct) { builder.build_metrics_struct }
+
+    context "with valid configuration" do
+      it "wraps each context in STRUCT" do
+        manifold_config["contexts"].each_key do |_context|
+          expect(metrics_struct).to include("STRUCT(")
+        end
+      end
+
+      it "includes each context name" do
+        manifold_config["contexts"].each_key do |context|
+          expect(metrics_struct).to include(") AS #{context}")
+        end
+      end
+
+      it "includes countif function" do
+        expect(metrics_struct).to include("COUNTIF(")
+      end
+
+      it "includes countif metric name" do
+        expect(metrics_struct).to include(") AS tapCount")
+      end
+
+      it "includes sumif function" do
+        expect(metrics_struct).to include("SUM(IF(")
+      end
+
+      it "includes sumif field reference" do
+        expect(metrics_struct).to include(", context.sequence, 0)")
+      end
+    end
+
+    context "when no contexts are defined" do
+      let(:manifold_config) { { "metrics" => {} } }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "when no metrics are defined" do
+      let(:manifold_config) { { "contexts" => {} } }
+
+      it { is_expected.to eq("") }
+    end
+  end
+end

--- a/spec/manifold/terraform/sql_builder_spec.rb
+++ b/spec/manifold/terraform/sql_builder_spec.rb
@@ -6,11 +6,8 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
   let(:name) { "analytics" }
   let(:manifold_config) do
     {
-      "source" => {
-        "table" => "bdg-wetland.EventStream.CardTaps",
-        "id_field" => "dimensions.cardZoneId",
-        "lookback" => "90 DAY"
-      },
+      "source" => "bdg-wetland.EventStream.CardTaps",
+      "filter" => "timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)",
       "timestamp" => {
         "field" => "timestamp",
         "interval" => "DAY"
@@ -28,16 +25,12 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
       expect(sql).to include("FROM `bdg-wetland.EventStream.CardTaps`")
     end
 
-    it "uses the configured id field" do
-      expect(sql).to include("dimensions.cardZoneId id")
-    end
-
     it "uses the configured timestamp field and interval" do
       expect(sql).to include("TIMESTAMP_TRUNC(timestamp, DAY) timestamp")
     end
 
-    it "uses the configured lookback" do
-      expect(sql).to include("INTERVAL 90 DAY")
+    it "uses the configured filter" do
+      expect(sql).to include("WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)")
     end
 
     it "includes the metrics struct" do
@@ -47,21 +40,15 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
     context "with default configuration" do
       let(:manifold_config) do
         {
-          "source" => { "table" => "bdg-wetland.EventStream.CardTaps" },
-          "timestamp" => { "field" => "timestamp" }
+          "source" => "bdg-wetland.EventStream.CardTaps",
+          "timestamp" => {
+            "field" => "timestamp"
+          }
         }
-      end
-
-      it "uses default id field" do
-        expect(sql).to include("dimensions.id id")
       end
 
       it "uses default interval" do
         expect(sql).to include("TIMESTAMP_TRUNC(timestamp, DAY)")
-      end
-
-      it "uses default lookback" do
-        expect(sql).to include("INTERVAL 90 DAY")
       end
     end
   end

--- a/spec/manifold/terraform/sql_builder_spec.rb
+++ b/spec/manifold/terraform/sql_builder_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::Terraform::SQLBuilder do
+  subject(:builder) { described_class.new(name, manifold_config) }
+
+  let(:name) { "analytics" }
+  let(:manifold_config) do
+    {
+      "source" => {
+        "table" => "bdg-wetland.EventStream.CardTaps",
+        "id_field" => "dimensions.cardZoneId",
+        "lookback" => "90 DAY"
+      },
+      "timestamp" => {
+        "field" => "timestamp",
+        "interval" => "DAY"
+      }
+    }
+  end
+
+  describe "#build_manifold_merge_sql" do
+    subject(:sql) { builder.build_manifold_merge_sql(metrics_builder) { metrics_struct } }
+
+    let(:metrics_builder) { instance_double(Manifold::Terraform::MetricsBuilder) }
+    let(:metrics_struct) { "STRUCT(COUNTIF(IS_PAID(context.location)) AS tapCount) AS paid" }
+
+    it "includes the source table" do
+      expect(sql).to include("FROM `bdg-wetland.EventStream.CardTaps`")
+    end
+
+    it "uses the configured id field" do
+      expect(sql).to include("dimensions.cardZoneId id")
+    end
+
+    it "uses the configured timestamp field and interval" do
+      expect(sql).to include("TIMESTAMP_TRUNC(timestamp, DAY) timestamp")
+    end
+
+    it "uses the configured lookback" do
+      expect(sql).to include("INTERVAL 90 DAY")
+    end
+
+    it "includes the metrics struct" do
+      expect(sql).to include(metrics_struct)
+    end
+
+    context "with default configuration" do
+      let(:manifold_config) do
+        {
+          "source" => { "table" => "bdg-wetland.EventStream.CardTaps" },
+          "timestamp" => { "field" => "timestamp" }
+        }
+      end
+
+      it "uses default id field" do
+        expect(sql).to include("dimensions.id id")
+      end
+
+      it "uses default interval" do
+        expect(sql).to include("TIMESTAMP_TRUNC(timestamp, DAY)")
+      end
+
+      it "uses default lookback" do
+        expect(sql).to include("INTERVAL 90 DAY")
+      end
+    end
+  end
+
+  describe "#build_dimensions_merge_sql" do
+    subject(:sql) { builder.build_dimensions_merge_sql(source_sql) }
+
+    let(:source_sql) { "SELECT id, STRUCT(url, title) AS dimensions FROM pages" }
+
+    it "includes the source SQL" do
+      expect(sql).to include(source_sql)
+    end
+
+    it "merges into the dimensions table" do
+      expect(sql).to include("MERGE #{name}.Dimensions AS TARGET")
+    end
+
+    it "updates dimensions on match" do
+      expect(sql).to include("WHEN MATCHED THEN UPDATE SET target.dimensions = source.dimensions")
+    end
+
+    it "inserts new rows" do
+      expect(sql).to include("WHEN NOT MATCHED THEN INSERT ROW")
+    end
+  end
+end

--- a/spec/manifold/terraform/table_config_builder_spec.rb
+++ b/spec/manifold/terraform/table_config_builder_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::Terraform::TableConfigBuilder do
+  subject(:builder) { described_class.new(name) }
+
+  let(:name) { "analytics" }
+
+  describe "#build_table_configs" do
+    subject(:configs) { builder.build_table_configs }
+
+    it "includes both dimensions and manifold tables" do
+      expect(configs.keys).to contain_exactly("dimensions", "manifold")
+    end
+
+    describe "dimensions table configuration" do
+      subject(:dimensions_config) { configs["dimensions"] }
+
+      it { is_expected.to include("dataset_id" => name) }
+      it { is_expected.to include("project" => "${var.project_id}") }
+      it { is_expected.to include("table_id" => "Dimensions") }
+      it { is_expected.to include("schema" => "${file(\"${path.module}/tables/dimensions.json\")}") }
+      it { is_expected.to include("depends_on" => ["google_bigquery_dataset.#{name}"]) }
+    end
+
+    describe "manifold table configuration" do
+      subject(:manifold_config) { configs["manifold"] }
+
+      it { is_expected.to include("dataset_id" => name) }
+      it { is_expected.to include("project" => "${var.project_id}") }
+      it { is_expected.to include("table_id" => "Manifold") }
+      it { is_expected.to include("schema" => "${file(\"${path.module}/tables/manifold.json\")}") }
+      it { is_expected.to include("depends_on" => ["google_bigquery_dataset.#{name}"]) }
+    end
+  end
+end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -14,11 +14,8 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
       "metrics" => {
         "countif" => "tapCount"
       },
-      "source" => {
-        "table" => "analytics.events",
-        "id_field" => "user_id",
-        "lookback" => "90 DAY"
-      },
+      "source" => "analytics.events",
+      "filter" => "timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)",
       "timestamp" => {
         "field" => "created_at",
         "interval" => "DAY"
@@ -109,8 +106,8 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         expect(definition_body).to include("TIMESTAMP_TRUNC(created_at, DAY)")
       end
 
-      it "uses timestamp field in WHERE clause" do
-        expect(definition_body).to include("WHERE created_at >= TIMESTAMP_SUB")
+      it "uses the configured filter" do
+        expect(definition_body).to include("WHERE timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)")
       end
 
       it "includes countif metrics" do

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
   subject(:config) { described_class.new(name) }
 
   let(:name) { "analytics" }
+  let(:manifold_config) do
+    {
+      "contexts" => {
+        "paid" => "IS_PAID(context.location)"
+      },
+      "metrics" => {
+        "countif" => "tapCount"
+      },
+      "source" => {
+        "table" => "analytics.events",
+        "id_field" => "user_id",
+        "lookback" => "90 DAY"
+      },
+      "timestamp" => {
+        "field" => "created_at",
+        "interval" => "DAY"
+      }
+    }
+  end
 
   describe "#as_json" do
     subject(:json) { config.as_json }
@@ -44,10 +63,58 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         config.merge_config = { "source" => "lib/routines/select_pages.sql" }
       end
 
-      it "includes routine configuration" do
+      it "includes dimensions merge routine configuration" do
         expect(json["resource"]["google_bigquery_routine"]).to include(
           "merge_dimensions" => expected_routine_config
         )
+      end
+    end
+
+    context "when manifold configuration is present" do
+      before do
+        config.manifold_config = manifold_config
+      end
+
+      let(:merge_manifold_routine) { json["resource"]["google_bigquery_routine"]["merge_manifold"] }
+      let(:definition_body) { merge_manifold_routine["definition_body"] }
+
+      it "includes merge_manifold routine" do
+        expect(json["resource"]["google_bigquery_routine"]).to include("merge_manifold")
+      end
+
+      it "configures the dataset" do
+        expect(merge_manifold_routine).to include(
+          "dataset_id" => name,
+          "project" => "${var.project_id}"
+        )
+      end
+
+      it "configures the routine type" do
+        expect(merge_manifold_routine).to include(
+          "routine_id" => "merge_manifold",
+          "routine_type" => "PROCEDURE",
+          "language" => "SQL"
+        )
+      end
+
+      it "includes the merge SQL" do
+        expect(definition_body).to include("MERGE analytics.Manifold AS target")
+      end
+
+      it "includes dataset dependency" do
+        expect(merge_manifold_routine["depends_on"]).to eq(["google_bigquery_dataset.#{name}"])
+      end
+
+      it "uses the configured timestamp field" do
+        expect(definition_body).to include("TIMESTAMP_TRUNC(created_at, DAY)")
+      end
+
+      it "uses timestamp field in WHERE clause" do
+        expect(definition_body).to include("WHERE created_at >= TIMESTAMP_SUB")
+      end
+
+      it "includes countif metrics" do
+        expect(definition_body).to include("COUNTIF(IS_PAID(context.location)) AS tapCount")
       end
     end
 
@@ -58,79 +125,81 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         expect(json["resource"]["google_bigquery_routine"]).to be_nil
       end
     end
+  end
 
-    def expected_dataset
-      {
-        "dataset_id" => name,
-        "project" => "${var.project_id}",
-        "location" => "US"
+  private
+
+  def expected_dataset
+    {
+      "dataset_id" => name,
+      "project" => "${var.project_id}",
+      "location" => "US"
+    }
+  end
+
+  def expected_dimensions_table
+    {
+      "dataset_id" => name,
+      "project" => "${var.project_id}",
+      "table_id" => "Dimensions",
+      "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
+      "depends_on" => ["google_bigquery_dataset.#{name}"]
+    }
+  end
+
+  def expected_manifold_table
+    {
+      "dataset_id" => name,
+      "project" => "${var.project_id}",
+      "table_id" => "Manifold",
+      "schema" => "${file(\"${path.module}/tables/manifold.json\")}",
+      "depends_on" => ["google_bigquery_dataset.#{name}"]
+    }
+  end
+
+  def expected_routine_config
+    {
+      "dataset_id" => name,
+      "project" => "${var.project_id}",
+      "routine_id" => "merge_dimensions",
+      "routine_type" => "PROCEDURE",
+      "language" => "SQL",
+      "definition_body" => expected_merge_routine,
+      "depends_on" => ["google_bigquery_dataset.#{name}"]
+    }
+  end
+
+  def expected_merge_routine
+    <<~SQL
+      MERGE #{name}.Dimensions AS TARGET
+      USING (
+        #{source_sql}
+      ) AS source
+      ON source.id = target.id
+      WHEN MATCHED THEN UPDATE SET target.dimensions = source.dimensions
+      WHEN NOT MATCHED THEN INSERT ROW;
+    SQL
+  end
+
+  def setup_merge_vector_config
+    Pathname.pwd.join("lib/routines").mkpath
+    Pathname.pwd.join("lib/routines/select_pages.sql").write(source_sql)
+  end
+
+  def vector_config
+    {
+      "name" => "Page",
+      "attributes" => {
+        "url" => "string",
+        "title" => "string"
+      },
+      "merge" => {
+        "source" => "lib/routines/select_pages.sql"
       }
-    end
+    }
+  end
 
-    def expected_dimensions_table
-      {
-        "dataset_id" => name,
-        "project" => "${var.project_id}",
-        "table_id" => "Dimensions",
-        "schema" => "${file(\"${path.module}/tables/dimensions.json\")}",
-        "depends_on" => ["google_bigquery_dataset.#{name}"]
-      }
-    end
-
-    def expected_manifold_table
-      {
-        "dataset_id" => name,
-        "project" => "${var.project_id}",
-        "table_id" => "Manifold",
-        "schema" => "${file(\"${path.module}/tables/manifold.json\")}",
-        "depends_on" => ["google_bigquery_dataset.#{name}"]
-      }
-    end
-
-    def expected_routine_config
-      {
-        "dataset_id" => name,
-        "project" => "${var.project_id}",
-        "routine_id" => "merge_dimensions",
-        "routine_type" => "PROCEDURE",
-        "language" => "SQL",
-        "definition_body" => expected_merge_routine,
-        "depends_on" => ["google_bigquery_dataset.#{name}"]
-      }
-    end
-
-    def expected_merge_routine
-      <<~SQL
-        MERGE #{name}.Dimensions AS TARGET
-        USING (
-          #{source_sql}
-        ) AS source
-        ON source.id = target.id
-        WHEN MATCHED THEN UPDATE SET target.dimensions = source.dimensions
-        WHEN NOT MATCHED THEN INSERT ROW;
-      SQL
-    end
-
-    def setup_merge_vector_config
-      Pathname.pwd.join("lib/routines").mkpath
-      Pathname.pwd.join("lib/routines/select_pages.sql").write(source_sql)
-    end
-
-    def vector_config
-      {
-        "name" => "Page",
-        "attributes" => {
-          "url" => "string",
-          "title" => "string"
-        },
-        "merge" => {
-          "source" => "lib/routines/select_pages.sql"
-        }
-      }
-    end
-
-    def vector_config_without_merge
-      vector_config.tap { |config| config.delete("merge") }
-    end
+  def vector_config_without_merge
+    vector_config.tap { |config| config.delete("merge") }
   end
 end


### PR DESCRIPTION
This PR adds support for generating BigQuery merge routines for Manifold tables. The merge routines are responsible for aggregating metrics across different contexts and dimensions.

For now, we support COUNTIF and SUM(IF...) style aggregations.

## Configuration Format
- Added support for a simplified source configuration format in `manifold.yml`:
  ```yaml
  source: my_project.my_dataset.my_table
  filter: timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
  timestamp:
    field: created_at
    interval: DAY
  ```

## SQL Generation
- Added `MetricsBuilder` class to handle complex metric aggregations:
  - Supports `COUNTIF` and `SUMIF` metrics
  - Handles nested context conditions with logical operators (AND, OR, NOT, etc.)
  - Generates properly structured metric fields in the output

- Added `SQLBuilder` class to generate merge routine SQL:
  - Generates CTE for metrics calculation
  - Properly handles timestamp truncation and filtering
  - Joins with dimensions table for complete manifold records
  - Implements MERGE semantics for upserting records

## Schema Validation
- Added validation for required manifold configuration fields:
  - Source table
  - Timestamp field
  - Contexts
  - Metrics
  
## Example
```yaml
timestamp:
  field: created_at
  interval: DAY

contexts:
  paid: IS_PAID(context.location)

metrics:
  countif: tapCount

source: analytics.events
```

will generate a merge 

1. Aggregates tap counts for paid contexts
2. Groups by day using the created_at field
3. Merges with existing dimensions
4. Updates or inserts records in the manifold table