### PR TITLE
Generate Routines in Separate Files

### DIFF
--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -25,6 +25,90 @@ module Manifold
       end
     end
 
+    # Handles SQL generation for manifold workspaces
+    class SqlGenerator
+      def initialize(name, manifold_yaml)
+        @name = name
+        @manifold_yaml = manifold_yaml
+      end
+
+      def generate_manifold_merge_sql
+        return unless valid_config?
+
+        metrics_builder = Terraform::MetricsBuilder.new(@manifold_yaml)
+        sql_builder = Terraform::SQLBuilder.new(@name, @manifold_yaml)
+        sql_builder.build_manifold_merge_sql(metrics_builder) do
+          metrics_builder.build_metrics_struct
+        end
+      end
+
+      private
+
+      def valid_config?
+        return false unless @manifold_yaml
+
+        %w[source timestamp.field contexts metrics].all? do |field|
+          @manifold_yaml&.dig(*field.split("."))
+        end
+      end
+    end
+
+    # Handles schema file generation for manifold workspaces
+    class SchemaWriter
+      def initialize(name, vectors, vector_service, manifold_yaml, logger)
+        @name = name
+        @vectors = vectors
+        @vector_service = vector_service
+        @manifold_yaml = manifold_yaml
+        @logger = logger
+      end
+
+      def write_schemas(tables_directory)
+        tables_directory.mkpath
+        write_dimensions_schema(tables_directory)
+        write_manifold_schema(tables_directory)
+      end
+
+      private
+
+      def write_dimensions_schema(tables_directory)
+        dimensions_path = tables_directory.join("dimensions.json")
+        dimensions_path.write(dimensions_schema_json.concat("\n"))
+      end
+
+      def write_manifold_schema(tables_directory)
+        manifold_path = tables_directory.join("manifold.json")
+        manifold_path.write(manifold_schema_json.concat("\n"))
+      end
+
+      def schema_generator
+        @schema_generator ||= SchemaGenerator.new(dimensions_fields, @manifold_yaml)
+      end
+
+      def manifold_schema
+        schema_generator.manifold_schema
+      end
+
+      def dimensions_schema
+        schema_generator.dimensions_schema
+      end
+
+      def dimensions_fields
+        @dimensions_fields ||= @vectors.filter_map do |vector|
+          @logger.info("Loading vector schema for '#{vector}'.")
+          @vector_service.load_vector_schema(vector)
+        end
+      end
+
+      def dimensions_schema_json
+        JSON.pretty_generate(dimensions_schema)
+      end
+
+      def manifold_schema_json
+        JSON.pretty_generate(manifold_schema)
+      end
+    end
+
     # Encapsulates a single manifold.
     class Workspace
       attr_reader :name, :template_path, :logger
@@ -52,13 +136,12 @@ module Manifold
       def generate(with_terraform: false)
         return nil unless manifold_exists? && any_vectors?
 
-        tables_directory.mkpath
-        generate_dimensions
-        generate_manifold
+        generate_schemas
         logger.info("Generated BigQuery dimensions table schema for workspace '#{name}'.")
 
         return unless with_terraform
 
+        write_manifold_merge_sql
         generate_terraform
         logger.info("Generated Terraform configuration for workspace '#{name}'.")
       end
@@ -89,6 +172,18 @@ module Manifold
         directory.join("main.tf.json")
       end
 
+      def write_manifold_merge_sql
+        sql = SqlGenerator.new(name, manifold_yaml).generate_manifold_merge_sql
+        return unless sql
+
+        routines_directory.mkpath
+        manifold_merge_sql_path.write(sql)
+      end
+
+      def manifold_merge_sql_path
+        routines_directory.join("merge_manifold.sql")
+      end
+
       private
 
       def directory
@@ -99,43 +194,9 @@ module Manifold
         @manifold_yaml ||= YAML.safe_load_file(manifold_path)
       end
 
-      def generate_dimensions
-        dimensions_path.write(dimensions_schema_json.concat("\n"))
-      end
-
-      def generate_manifold
-        manifold_schema_path.write(manifold_schema_json.concat("\n"))
-      end
-
-      def manifold_schema_path
-        tables_directory.join("manifold.json")
-      end
-
-      def schema_generator
-        @schema_generator ||= SchemaGenerator.new(dimensions_fields, manifold_yaml)
-      end
-
-      def manifold_schema
-        schema_generator.manifold_schema
-      end
-
-      def dimensions_schema
-        schema_generator.dimensions_schema
-      end
-
-      def dimensions_fields
-        @dimensions_fields ||= vectors.filter_map do |vector|
-          logger.info("Loading vector schema for '#{vector}'.")
-          @vector_service.load_vector_schema(vector)
-        end
-      end
-
-      def dimensions_schema_json
-        JSON.pretty_generate(dimensions_schema)
-      end
-
-      def dimensions_path
-        tables_directory.join("dimensions.json")
+      def generate_schemas
+        SchemaWriter.new(name, vectors, @vector_service, manifold_yaml, logger)
+                    .write_schemas(tables_directory)
       end
 
       def any_vectors?
@@ -150,10 +211,6 @@ module Manifold
         terraform_generator = TerraformGenerator.new(name, vectors, @vector_service, manifold_yaml)
         terraform_generator.manifold_config = manifold_yaml
         terraform_generator.generate(terraform_main_path)
-      end
-
-      def manifold_schema_json
-        JSON.pretty_generate(manifold_schema)
       end
     end
   end

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -280,7 +280,7 @@ module Manifold
           "routine_id" => "merge_dimensions",
           "routine_type" => "PROCEDURE",
           "language" => "SQL",
-          "definition_body" => dimensions_merge_routine,
+          "definition_body" => "${file(\"${path.module}/routines/merge_dimensions.sql\")}",
           "depends_on" => ["google_bigquery_dataset.#{name}"]
         }
       end

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -144,7 +144,11 @@ module Manifold
 
       def build_final_select
         <<~SQL
-          SELECT id, timestamp, #{@name}.Dimensions.dimensions, Metrics.metrics
+          SELECT
+            id,
+            timestamp,
+            #{@name}.Dimensions.dimensions,
+            Metrics.metrics
           FROM Metrics
           LEFT JOIN #{@name}.Dimensions USING (id)
         SQL

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -301,7 +301,7 @@ module Manifold
           "routine_id" => "merge_manifold",
           "routine_type" => "PROCEDURE",
           "language" => "SQL",
-          "definition_body" => manifold_merge_routine,
+          "definition_body" => "${file(\"${path.module}/routines/merge_manifold.sql\")}",
           "depends_on" => ["google_bigquery_dataset.#{name}"]
         }
       end

--- a/spec/manifold/terraform/sql_builder_spec.rb
+++ b/spec/manifold/terraform/sql_builder_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
     let(:source_sql) do
       <<~SQL
         SELECT
-        id,
-        STRUCT(
-          (SELECT AS STRUCT Cards.*) AS card
-        ) AS dimensions
+          id,
+          STRUCT(
+            (SELECT AS STRUCT Cards.*) AS card
+          ) AS dimensions
         FROM Gradius.Cards
       SQL
     end

--- a/spec/manifold/terraform/sql_builder_spec.rb
+++ b/spec/manifold/terraform/sql_builder_spec.rb
@@ -56,14 +56,23 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
   describe "#build_dimensions_merge_sql" do
     subject(:sql) { builder.build_dimensions_merge_sql(source_sql) }
 
-    let(:source_sql) { "SELECT id, STRUCT(url, title) AS dimensions FROM pages" }
-
-    it "includes the source SQL" do
-      expect(sql).to include(source_sql)
+    let(:source_sql) do
+      <<~SQL
+        SELECT
+        id,
+        STRUCT(
+          (SELECT AS STRUCT Cards.*) AS card
+        ) AS dimensions
+        FROM Gradius.Cards
+      SQL
     end
 
     it "merges into the dimensions table" do
       expect(sql).to include("MERGE #{name}.Dimensions AS TARGET")
+    end
+
+    it "includes the source SQL" do
+      expect(sql).to include("(SELECT AS STRUCT Cards.*) AS card")
     end
 
     it "updates dimensions on match" do

--- a/spec/support/shared_contexts/with_template_files.rb
+++ b/spec/support/shared_contexts/with_template_files.rb
@@ -4,7 +4,17 @@ RSpec.shared_context "with template files" do
   before do
     template_dir.mkpath
 
-    workspace_template_path.write("vectors:\nmetrics:")
+    workspace_template_path.write(<<~YAML)
+      vectors:
+      source: analytics.events
+      timestamp:
+        field: created_at
+        interval: DAY
+      contexts:
+        paid: IS_PAID(context.location)
+      metrics:
+        countif: tapCount
+    YAML
     vector_template_path.write("attributes:")
   end
 


### PR DESCRIPTION
Updates how we handle SQL generation for merge routines in the Manifold workspace. Instead of embedding SQL directly in the terraform configuration, we now generate separate SQL files for both dimensions and manifold merge routines.

This makes the routines a little more legible, easier to reason about and easier to debug than when they're jammed into the JSON generation.

## SQL File Generation
- Added `write_dimensions_merge_sql` to generate a separate SQL file for dimensions merge routines
- Added `generate_dimensions_merge_sql` to handle SQL generation logic
- Updated `SqlGenerator` to validate dimensions merge configuration separately from manifold merge configuration

## Terraform Configuration
- Updated `WorkspaceConfiguration` to reference SQL files instead of embedding SQL inline
- Both `merge_manifold` and `merge_dimensions` routines now use `${file()}` to read SQL from files
- Maintained all existing functionality while improving code organization
