### PR TITLE
Contexts -> Breakouts, Metrics -> Aggregations

### DIFF
--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -33,19 +33,19 @@ module Manifold
       private
 
       def metrics_fields
-        return [] unless @manifold_yaml["contexts"] && @manifold_yaml["metrics"]
+        return [] unless @manifold_yaml["breakouts"] && @manifold_yaml["metrics"]
 
-        @manifold_yaml["contexts"].map do |context_name, _context_config|
+        @manifold_yaml["breakouts"].map do |breakout_name, _breakout_config|
           {
-            "name" => context_name,
+            "name" => breakout_name,
             "type" => "RECORD",
             "mode" => "NULLABLE",
-            "fields" => context_metrics_fields
+            "fields" => breakout_metrics_fields
           }
         end
       end
 
-      def context_metrics_fields
+      def breakout_metrics_fields
         [
           *countif_fields,
           *sumif_fields

--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -33,7 +33,7 @@ module Manifold
       private
 
       def metrics_fields
-        return [] unless @manifold_yaml["breakouts"] && @manifold_yaml["metrics"]
+        return [] unless @manifold_yaml["breakouts"] && @manifold_yaml["aggregations"]
 
         @manifold_yaml["breakouts"].map do |breakout_name, _breakout_config|
           {
@@ -53,19 +53,19 @@ module Manifold
       end
 
       def countif_fields
-        return [] unless @manifold_yaml.dig("metrics", "countif")
+        return [] unless @manifold_yaml.dig("aggregations", "countif")
 
         [{
-          "name" => @manifold_yaml["metrics"]["countif"],
+          "name" => @manifold_yaml["aggregations"]["countif"],
           "type" => "INTEGER",
           "mode" => "NULLABLE"
         }]
       end
 
       def sumif_fields
-        return [] unless @manifold_yaml.dig("metrics", "sumif")
+        return [] unless @manifold_yaml.dig("aggregations", "sumif")
 
-        @manifold_yaml["metrics"]["sumif"].keys.map do |metric_name|
+        @manifold_yaml["aggregations"]["sumif"].keys.map do |metric_name|
           {
             "name" => metric_name,
             "type" => "INTEGER",

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -54,7 +54,7 @@ module Manifold
       def valid_manifold_config?
         return false unless @manifold_yaml
 
-        %w[source timestamp.field breakouts metrics].all? do |field|
+        %w[source timestamp.field breakouts aggregations].all? do |field|
           @manifold_yaml&.dig(*field.split("."))
         end
       end

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -54,7 +54,7 @@ module Manifold
       def valid_manifold_config?
         return false unless @manifold_yaml
 
-        %w[source timestamp.field contexts metrics].all? do |field|
+        %w[source timestamp.field breakouts metrics].all? do |field|
           @manifold_yaml&.dig(*field.split("."))
         end
       end

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -12,7 +12,7 @@ timestamp:
   interval: HOUR
   field: timestamp
 
-contexts:
+breakouts:
   paid: IS_PAID(context.location)
   organic: IS_ORGANIC(context.location)
   paidOrganic:

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -21,7 +21,7 @@ breakouts:
       - organic
     operator: AND
 
-metrics:
+aggregations:
   countif: tapCount
   sumif:
     sequenceSum:

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -9,7 +9,7 @@ module Manifold
       end
 
       def build_metrics_struct
-        return "" unless @manifold_config&.dig("breakouts") && @manifold_config&.dig("metrics")
+        return "" unless @manifold_config&.dig("breakouts") && @manifold_config&.dig("aggregations")
 
         breakout_structs = @manifold_config["breakouts"].map do |name, config|
           condition = build_breakout_condition(name, config)
@@ -30,13 +30,13 @@ module Manifold
       end
 
       def add_count_metrics(metrics, condition)
-        return unless @manifold_config.dig("metrics", "countif")
+        return unless @manifold_config.dig("aggregations", "countif")
 
-        metrics << "COUNTIF(#{condition}) AS #{@manifold_config["metrics"]["countif"]}"
+        metrics << "COUNTIF(#{condition}) AS #{@manifold_config["aggregations"]["countif"]}"
       end
 
       def add_sum_metrics(metrics, condition)
-        @manifold_config.dig("metrics", "sumif")&.each do |name, config|
+        @manifold_config.dig("aggregations", "sumif")&.each do |name, config|
           metrics << "SUM(IF(#{condition}, #{config["field"]}, 0)) AS #{name}"
         end
       end
@@ -325,7 +325,7 @@ module Manifold
       end
 
       def required_fields_present?
-        %w[source timestamp.field breakouts metrics].all? do |field|
+        %w[source timestamp.field breakouts aggregations].all? do |field|
           @manifold_config&.dig(*field.split("."))
         end
       end

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -9,20 +9,20 @@ module Manifold
       end
 
       def build_metrics_struct
-        return "" unless @manifold_config&.dig("contexts") && @manifold_config&.dig("metrics")
+        return "" unless @manifold_config&.dig("breakouts") && @manifold_config&.dig("metrics")
 
-        context_structs = @manifold_config["contexts"].map do |name, config|
-          condition = build_context_condition(name, config)
-          metrics = build_context_metrics(condition)
+        breakout_structs = @manifold_config["breakouts"].map do |name, config|
+          condition = build_breakout_condition(name, config)
+          metrics = build_breakout_metrics(condition)
           "\tSTRUCT(\n\t\t#{metrics}\n\t) AS #{name}"
         end
 
-        context_structs.join(",\n")
+        breakout_structs.join(",\n")
       end
 
       private
 
-      def build_context_metrics(condition)
+      def build_breakout_metrics(condition)
         metrics = []
         add_count_metrics(metrics, condition)
         add_sum_metrics(metrics, condition)
@@ -41,7 +41,7 @@ module Manifold
         end
       end
 
-      def build_context_condition(_name, config)
+      def build_breakout_condition(_name, config)
         return config unless config.is_a?(Hash)
 
         operator = config["operator"]
@@ -50,7 +50,7 @@ module Manifold
       end
 
       def build_operator_condition(operator, fields)
-        conditions = fields.map { |f| @manifold_config["contexts"][f] }
+        conditions = fields.map { |f| @manifold_config["breakouts"][f] }
         case operator
         when "AND", "OR" then join_conditions(conditions, operator)
         when "NOT" then negate_condition(conditions.first)
@@ -325,7 +325,7 @@ module Manifold
       end
 
       def required_fields_present?
-        %w[source timestamp.field contexts metrics].all? do |field|
+        %w[source timestamp.field breakouts metrics].all? do |field|
           @manifold_config&.dig(*field.split("."))
         end
       end

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Manifold::API::Workspace do
         workspace.manifold_path.write(<<~YAML)
           vectors:
             - User
-          contexts:
+          breakouts:
             paid: IS_PAID(context.location)
             organic: IS_ORGANIC(context.location)
             paidOrganic:
@@ -173,8 +173,8 @@ RSpec.describe Manifold::API::Workspace do
         expect(schema_fields[:metrics]["mode"]).to eq("REQUIRED")
       end
 
-      shared_examples "context metrics" do |context_name|
-        let(:context) { schema_fields[:metrics]["fields"].find { |f| f["name"] == context_name } }
+      shared_examples "context metrics" do |breakout_name|
+        let(:context) { schema_fields[:metrics]["fields"].find { |f| f["name"] == breakout_name } }
 
         it "includes tapCount metric" do
           expect(context["fields"]).to include(
@@ -199,12 +199,12 @@ RSpec.describe Manifold::API::Workspace do
       include_examples "context metrics", "eitherPaidOrOrganic"
       include_examples "context metrics", "similarPaidOrganic"
 
-      it "includes all contexts in the metrics fields" do
+      it "includes all breakouts in the metrics fields" do
         expect(schema_fields[:metrics]["fields"].map { |f| f["name"] })
-          .to match_array(expected_context_names)
+          .to match_array(expected_breakout_names)
       end
 
-      def expected_context_names
+      def expected_breakout_names
         %w[
           paid organic paidOrganic paidOrOrganic notPaid
           neitherPaidNorOrganic notBothPaidAndOrganic
@@ -329,7 +329,7 @@ RSpec.describe Manifold::API::Workspace do
           timestamp:
             field: created_at
             interval: DAY
-          contexts:
+          breakouts:
             paid: IS_PAID(context.location)
           metrics:
             countif: tapCount

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Manifold::API::Workspace do
                 - paid
                 - organic
               operator: XNOR
-          metrics:
+          aggregations:
             countif: tapCount
             sumif:
               sequenceSum:
@@ -331,7 +331,7 @@ RSpec.describe Manifold::API::Workspace do
             interval: DAY
           breakouts:
             paid: IS_PAID(context.location)
-          metrics:
+          aggregations:
             countif: tapCount
         YAML
       end

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -173,31 +173,31 @@ RSpec.describe Manifold::API::Workspace do
         expect(schema_fields[:metrics]["mode"]).to eq("REQUIRED")
       end
 
-      shared_examples "context metrics" do |breakout_name|
-        let(:context) { schema_fields[:metrics]["fields"].find { |f| f["name"] == breakout_name } }
+      shared_examples "breakout metrics" do |breakout_name|
+        let(:breakout) { schema_fields[:metrics]["fields"].find { |f| f["name"] == breakout_name } }
 
         it "includes tapCount metric" do
-          expect(context["fields"]).to include(
+          expect(breakout["fields"]).to include(
             { "type" => "INTEGER", "name" => "tapCount", "mode" => "NULLABLE" }
           )
         end
 
         it "includes sequenceSum metric" do
-          expect(context["fields"]).to include(
+          expect(breakout["fields"]).to include(
             { "type" => "INTEGER", "name" => "sequenceSum", "mode" => "NULLABLE" }
           )
         end
       end
 
-      include_examples "context metrics", "paid"
-      include_examples "context metrics", "organic"
-      include_examples "context metrics", "paidOrganic"
-      include_examples "context metrics", "paidOrOrganic"
-      include_examples "context metrics", "notPaid"
-      include_examples "context metrics", "neitherPaidNorOrganic"
-      include_examples "context metrics", "notBothPaidAndOrganic"
-      include_examples "context metrics", "eitherPaidOrOrganic"
-      include_examples "context metrics", "similarPaidOrganic"
+      include_examples "breakout metrics", "paid"
+      include_examples "breakout metrics", "organic"
+      include_examples "breakout metrics", "paidOrganic"
+      include_examples "breakout metrics", "paidOrOrganic"
+      include_examples "breakout metrics", "notPaid"
+      include_examples "breakout metrics", "neitherPaidNorOrganic"
+      include_examples "breakout metrics", "notBothPaidAndOrganic"
+      include_examples "breakout metrics", "eitherPaidOrOrganic"
+      include_examples "breakout metrics", "similarPaidOrganic"
 
       it "includes all breakouts in the metrics fields" do
         expect(schema_fields[:metrics]["fields"].map { |f| f["name"] })

--- a/spec/manifold/terraform/metrics_builder_spec.rb
+++ b/spec/manifold/terraform/metrics_builder_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
           "operator" => "XNOR"
         }
       },
-      "metrics" => {
+      "aggregations" => {
         "countif" => "tapCount",
         "sumif" => {
           "sequenceSum" => {
@@ -82,13 +82,13 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
     end
 
     context "when no breakouts are defined" do
-      let(:manifold_config) { { "metrics" => {} } }
+      let(:manifold_config) { { "breakouts" => {} } }
 
       it { is_expected.to eq("") }
     end
 
-    context "when no metrics are defined" do
-      let(:manifold_config) { { "breakouts" => {} } }
+    context "when no aggregations are defined" do
+      let(:manifold_config) { { "aggregations" => {} } }
 
       it { is_expected.to eq("") }
     end

--- a/spec/manifold/terraform/metrics_builder_spec.rb
+++ b/spec/manifold/terraform/metrics_builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
 
   let(:manifold_config) do
     {
-      "contexts" => {
+      "breakouts" => {
         "paid" => "IS_PAID(context.location)",
         "organic" => "IS_ORGANIC(context.location)",
         "paidOrganic" => {
@@ -53,13 +53,13 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
 
     context "with valid configuration" do
       it "wraps each context in STRUCT" do
-        manifold_config["contexts"].each_key do |_context|
+        manifold_config["breakouts"].each_key do |_context|
           expect(metrics_struct).to include("STRUCT(")
         end
       end
 
       it "includes each context name" do
-        manifold_config["contexts"].each_key do |context|
+        manifold_config["breakouts"].each_key do |context|
           expect(metrics_struct).to include(") AS #{context}")
         end
       end
@@ -81,14 +81,14 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
       end
     end
 
-    context "when no contexts are defined" do
+    context "when no breakouts are defined" do
       let(:manifold_config) { { "metrics" => {} } }
 
       it { is_expected.to eq("") }
     end
 
     context "when no metrics are defined" do
-      let(:manifold_config) { { "contexts" => {} } }
+      let(:manifold_config) { { "breakouts" => {} } }
 
       it { is_expected.to eq("") }
     end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
       "breakouts" => {
         "paid" => "IS_PAID(context.location)"
       },
-      "metrics" => {
+      "aggregations" => {
         "countif" => "tapCount"
       },
       "source" => "analytics.events",
@@ -114,8 +114,8 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
             interval: #{manifold_config["timestamp"]["interval"]}
           breakouts:
             paid: #{manifold_config["breakouts"]["paid"]}
-          metrics:
-            countif: #{manifold_config["metrics"]["countif"]}
+          aggregations:
+            countif: #{manifold_config["aggregations"]["countif"]}
           filter: #{manifold_config["filter"]}
         YAML
         workspace.write_manifold_merge_sql

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
   let(:name) { "analytics" }
   let(:manifold_config) do
     {
-      "contexts" => {
+      "breakouts" => {
         "paid" => "IS_PAID(context.location)"
       },
       "metrics" => {
@@ -112,8 +112,8 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
           timestamp:
             field: #{manifold_config["timestamp"]["field"]}
             interval: #{manifold_config["timestamp"]["interval"]}
-          contexts:
-            paid: #{manifold_config["contexts"]["paid"]}
+          breakouts:
+            paid: #{manifold_config["breakouts"]["paid"]}
           metrics:
             countif: #{manifold_config["metrics"]["countif"]}
           filter: #{manifold_config["filter"]}

--- a/spec/support/shared_contexts/with_template_files.rb
+++ b/spec/support/shared_contexts/with_template_files.rb
@@ -10,7 +10,7 @@ RSpec.shared_context "with template files" do
       timestamp:
         field: created_at
         interval: DAY
-      contexts:
+      breakouts:
         paid: IS_PAID(context.location)
       metrics:
         countif: tapCount

--- a/spec/support/shared_contexts/with_template_files.rb
+++ b/spec/support/shared_contexts/with_template_files.rb
@@ -12,7 +12,7 @@ RSpec.shared_context "with template files" do
         interval: DAY
       breakouts:
         paid: IS_PAID(context.location)
-      metrics:
+      aggregations:
         countif: tapCount
     YAML
     vector_template_path.write("attributes:")


### PR DESCRIPTION
In preparation for a larger restructuring of the manifold yml, renames context to breakout and metrics to aggregation. We'll nest these under a new `metrics` hash in the yaml, so I'm freeing the name.