### PR TITLE
Multiple Metrics Groups

### DIFF
--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -87,12 +87,6 @@ module Manifold
         end
       end
 
-      def metric_group?(key)
-        return false unless @manifold_yaml[key].is_a?(Hash)
-
-        @manifold_yaml[key]["breakouts"] && @manifold_yaml[key]["aggregations"]
-      end
-
       def validate_operator!(operator)
         return if VALID_OPERATORS.include?(operator)
 

--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -37,7 +37,7 @@ module Manifold
           {
             "name" => group_name,
             "type" => "RECORD",
-            "mode" => "REQUIRED",
+            "mode" => "NULLABLE",
             "fields" => group_metrics_fields(group_config)
           }
         end

--- a/lib/manifold/api/schema_generator.rb
+++ b/lib/manifold/api/schema_generator.rb
@@ -4,8 +4,6 @@ module Manifold
   module API
     # Handles schema generation for Manifold tables
     class SchemaGenerator
-      VALID_OPERATORS = %w[AND OR NOT NAND NOR XOR XNOR].freeze
-
       def initialize(dimensions_fields, manifold_yaml)
         @dimensions_fields = dimensions_fields
         @manifold_yaml = manifold_yaml
@@ -85,12 +83,6 @@ module Manifold
             "mode" => "NULLABLE"
           }
         end
-      end
-
-      def validate_operator!(operator)
-        return if VALID_OPERATORS.include?(operator)
-
-        raise ArgumentError, "Invalid operator: #{operator}. Valid operators are: #{VALID_OPERATORS.join(", ")}"
       end
     end
   end

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -32,16 +32,6 @@ module Manifold
         @manifold_yaml = manifold_yaml
       end
 
-      def generate_manifold_merge_sql
-        return unless valid_manifold_config?
-
-        metrics_builder = Terraform::MetricsBuilder.new(@manifold_yaml)
-        sql_builder = Terraform::SQLBuilder.new(@name, @manifold_yaml)
-        sql_builder.build_manifold_merge_sql(metrics_builder) do
-          metrics_builder.build_metrics_struct
-        end
-      end
-
       def generate_dimensions_merge_sql(source_sql)
         return unless valid_dimensions_config?
 
@@ -50,14 +40,6 @@ module Manifold
       end
 
       private
-
-      def valid_manifold_config?
-        return false unless @manifold_yaml
-
-        %w[source timestamp.field breakouts aggregations].all? do |field|
-          @manifold_yaml&.dig(*field.split("."))
-        end
-      end
 
       def valid_dimensions_config?
         return false unless @manifold_yaml
@@ -219,10 +201,6 @@ module Manifold
       def write_dimensions_merge_sql_file(sql)
         routines_directory.mkpath
         dimensions_merge_sql_path.write(sql)
-      end
-
-      def manifold_merge_sql_path
-        routines_directory.join("merge_manifold.sql")
       end
 
       def dimensions_merge_sql_path

--- a/lib/manifold/cli.rb
+++ b/lib/manifold/cli.rb
@@ -4,7 +4,7 @@ module Manifold
   # CLI provides command line interface functionality
   # for creating and managing umbrella projects for data management.
   class CLI < Thor
-    attr_accessor :logger, :bq_service
+    attr_accessor :logger
 
     def initialize(*args, logger: Logger.new($stdout))
       super(*args)

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -12,20 +12,31 @@ timestamp:
   interval: HOUR
   field: timestamp
 
-breakouts:
-  paid: IS_PAID(context.location)
-  organic: IS_ORGANIC(context.location)
-  paidOrganic:
-    fields:
-      - paid
-      - organic
-    operator: AND
+metrics:
+  renders:
+    breakouts:
+      paid: IS_PAID(context.location)
+      organic: IS_ORGANIC(context.location)
 
-aggregations:
-  countif: tapCount
-  sumif:
-    sequenceSum:
-      field: context.sequence
+    aggregations:
+      countif: renderCount
+      sumif:
+        sequenceSum:
+          field: context.sequence
 
-source: my_project.my_dataset.my_table
-filter: timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+    source: my_project.my_dataset.my_table
+    filter: timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+
+  taps:
+    breakouts:
+      paid: IS_PAID(context.location)
+      organic: IS_ORGANIC(context.location)
+
+    aggregations:
+      countif: tapCount
+      sumif:
+        sequenceSum:
+          field: context.sequence
+
+    source: my_project.my_dataset.my_table
+    filter: timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -15,8 +15,6 @@ module Manifold
           build_group_struct(group_name, group_config)
         end
 
-        return "" if metric_groups.empty?
-
         metric_groups.join(",\n")
       end
 

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -71,12 +71,6 @@ module Manifold
         end
       end
 
-      def metric_group?(key)
-        return false unless @manifold_config[key].is_a?(Hash)
-
-        @manifold_config[key]["breakouts"] && @manifold_config[key]["aggregations"]
-      end
-
       def build_breakout_condition(_name, config, group_config)
         return config unless config.is_a?(Hash)
 

--- a/lib/manifold/terraform/workspace_configuration.rb
+++ b/lib/manifold/terraform/workspace_configuration.rb
@@ -321,13 +321,6 @@ module Manifold
         }
       end
 
-      def dimensions_merge_routine
-        return "" if @vectors.empty? || @dimensions_config.nil?
-
-        source_sql = File.read(Pathname.pwd.join(@dimensions_config["source"]))
-        SQLBuilder.new(name, @manifold_config).build_dimensions_merge_sql(source_sql)
-      end
-
       def manifold_routine_attributes
         {
           "dataset_id" => name,
@@ -338,14 +331,6 @@ module Manifold
           "definition_body" => "${file(\"${path.module}/routines/merge_manifold.sql\")}",
           "depends_on" => ["google_bigquery_dataset.#{name}"]
         }
-      end
-
-      def manifold_merge_routine
-        metrics_builder = MetricsBuilder.new(@manifold_config)
-        sql_builder = SQLBuilder.new(name, @manifold_config)
-        sql_builder.build_manifold_merge_sql(metrics_builder) do
-          metrics_builder.build_metrics_struct
-        end
       end
     end
   end

--- a/spec/manifold/terraform/metrics_builder_spec.rb
+++ b/spec/manifold/terraform/metrics_builder_spec.rb
@@ -5,43 +5,47 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
 
   let(:manifold_config) do
     {
-      "breakouts" => {
-        "paid" => "IS_PAID(context.location)",
-        "organic" => "IS_ORGANIC(context.location)",
-        "paidOrganic" => {
-          "fields" => %w[paid organic],
-          "operator" => "AND"
-        },
-        "paidOrOrganic" => {
-          "fields" => %w[paid organic],
-          "operator" => "OR"
-        },
-        "notPaid" => {
-          "fields" => ["paid"],
-          "operator" => "NOT"
-        },
-        "neitherPaidNorOrganic" => {
-          "fields" => %w[paid organic],
-          "operator" => "NOR"
-        },
-        "notBothPaidAndOrganic" => {
-          "fields" => %w[paid organic],
-          "operator" => "NAND"
-        },
-        "eitherPaidOrOrganic" => {
-          "fields" => %w[paid organic],
-          "operator" => "XOR"
-        },
-        "similarPaidOrganic" => {
-          "fields" => %w[paid organic],
-          "operator" => "XNOR"
-        }
-      },
-      "aggregations" => {
-        "countif" => "tapCount",
-        "sumif" => {
-          "sequenceSum" => {
-            "field" => "context.sequence"
+      "metrics" => {
+        "taps" => {
+          "breakouts" => {
+            "paid" => "IS_PAID(context.location)",
+            "organic" => "IS_ORGANIC(context.location)",
+            "paidOrganic" => {
+              "fields" => %w[paid organic],
+              "operator" => "AND"
+            },
+            "paidOrOrganic" => {
+              "fields" => %w[paid organic],
+              "operator" => "OR"
+            },
+            "notPaid" => {
+              "fields" => ["paid"],
+              "operator" => "NOT"
+            },
+            "neitherPaidNorOrganic" => {
+              "fields" => %w[paid organic],
+              "operator" => "NOR"
+            },
+            "notBothPaidAndOrganic" => {
+              "fields" => %w[paid organic],
+              "operator" => "NAND"
+            },
+            "eitherPaidOrOrganic" => {
+              "fields" => %w[paid organic],
+              "operator" => "XOR"
+            },
+            "similarPaidOrganic" => {
+              "fields" => %w[paid organic],
+              "operator" => "XNOR"
+            }
+          },
+          "aggregations" => {
+            "countif" => "tapCount",
+            "sumif" => {
+              "sequenceSum" => {
+                "field" => "context.sequence"
+              }
+            }
           }
         }
       }
@@ -53,14 +57,14 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
 
     context "with valid configuration" do
       it "wraps each context in STRUCT" do
-        manifold_config["breakouts"].each_key do |_context|
+        manifold_config["metrics"]["taps"]["breakouts"].each_key do |_breakout|
           expect(metrics_struct).to include("STRUCT(")
         end
       end
 
       it "includes each context name" do
-        manifold_config["breakouts"].each_key do |context|
-          expect(metrics_struct).to include(") AS #{context}")
+        manifold_config["metrics"]["taps"]["breakouts"].each_key do |breakout|
+          expect(metrics_struct).to include(") AS #{breakout}")
         end
       end
 
@@ -81,14 +85,42 @@ RSpec.describe Manifold::Terraform::MetricsBuilder do
       end
     end
 
+    context "when no metrics are defined" do
+      let(:manifold_config) { {} }
+
+      it { is_expected.to eq("") }
+    end
+
     context "when no breakouts are defined" do
-      let(:manifold_config) { { "breakouts" => {} } }
+      let(:manifold_config) do
+        {
+          "metrics" => {
+            "taps" => {
+              "breakouts" => {},
+              "aggregations" => {
+                "countif" => "tapCount"
+              }
+            }
+          }
+        }
+      end
 
       it { is_expected.to eq("") }
     end
 
     context "when no aggregations are defined" do
-      let(:manifold_config) { { "aggregations" => {} } }
+      let(:manifold_config) do
+        {
+          "metrics" => {
+            "taps" => {
+              "breakouts" => {
+                "paid" => "IS_PAID(context.location)"
+              },
+              "aggregations" => {}
+            }
+          }
+        }
+      end
 
       it { is_expected.to eq("") }
     end

--- a/spec/manifold/terraform/sql_builder_spec.rb
+++ b/spec/manifold/terraform/sql_builder_spec.rb
@@ -6,11 +6,21 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
   let(:name) { "analytics" }
   let(:manifold_config) do
     {
-      "source" => "`bdg-wetland.EventStream.CardTaps`",
-      "filter" => "timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)",
       "timestamp" => {
         "field" => "timestamp",
         "interval" => "DAY"
+      },
+      "metrics" => {
+        "taps" => {
+          "source" => "`bdg-wetland.EventStream.CardTaps`",
+          "filter" => "timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)",
+          "breakouts" => {
+            "paid" => "IS_PAID(context.location)"
+          },
+          "aggregations" => {
+            "countif" => "tapCount"
+          }
+        }
       }
     }
   end
@@ -40,9 +50,19 @@ RSpec.describe Manifold::Terraform::SQLBuilder do
     context "with default configuration" do
       let(:manifold_config) do
         {
-          "source" => "bdg-wetland.EventStream.CardTaps",
           "timestamp" => {
             "field" => "timestamp"
+          },
+          "metrics" => {
+            "taps" => {
+              "source" => "bdg-wetland.EventStream.CardTaps",
+              "breakouts" => {
+                "paid" => "IS_PAID(context.location)"
+              },
+              "aggregations" => {
+                "countif" => "tapCount"
+              }
+            }
           }
         }
       end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -219,18 +219,6 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
     }
   end
 
-  def expected_merge_routine
-    <<~SQL
-      MERGE #{name}.Dimensions AS TARGET
-      USING (
-        #{source_sql}
-      ) AS source
-      ON source.id = target.id
-      WHEN MATCHED THEN UPDATE SET target.dimensions = source.dimensions
-      WHEN NOT MATCHED THEN INSERT ROW;
-    SQL
-  end
-
   def setup_merge_vector_config
     Pathname.pwd.join("lib/routines").mkpath
     Pathname.pwd.join("lib/routines/select_pages.sql").write(source_sql)
@@ -247,9 +235,5 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         "source" => "lib/routines/select_pages.sql"
       }
     }
-  end
-
-  def vector_config_without_merge
-    vector_config.tap { |config| config.delete("merge") }
   end
 end

--- a/spec/manifold/terraform/workspace_configuration_spec.rb
+++ b/spec/manifold/terraform/workspace_configuration_spec.rb
@@ -8,17 +8,21 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
   let(:name) { "analytics" }
   let(:manifold_config) do
     {
-      "breakouts" => {
-        "paid" => "IS_PAID(context.location)"
-      },
-      "aggregations" => {
-        "countif" => "tapCount"
-      },
-      "source" => "analytics.events",
-      "filter" => "timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)",
       "timestamp" => {
         "field" => "created_at",
         "interval" => "DAY"
+      },
+      "metrics" => {
+        "taps" => {
+          "breakouts" => {
+            "paid" => "IS_PAID(context.location)"
+          },
+          "aggregations" => {
+            "countif" => "tapCount"
+          },
+          "source" => "analytics.events",
+          "filter" => "timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)"
+        }
       }
     }
   end
@@ -66,7 +70,7 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
       before do
         setup_merge_vector_config
         config.add_vector(vector_config)
-        config.merge_config = { "source" => "lib/routines/select_pages.sql" }
+        config.dimensions_config = { "source" => "lib/routines/select_pages.sql" }
 
         workspace = Manifold::API::Workspace.new(name)
         workspace.add
@@ -108,15 +112,17 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
         workspace.manifold_path.write(<<~YAML)
           vectors:
             - Page
-          source: #{manifold_config["source"]}
           timestamp:
             field: #{manifold_config["timestamp"]["field"]}
             interval: #{manifold_config["timestamp"]["interval"]}
-          breakouts:
-            paid: #{manifold_config["breakouts"]["paid"]}
-          aggregations:
-            countif: #{manifold_config["aggregations"]["countif"]}
-          filter: #{manifold_config["filter"]}
+          metrics:
+            taps:
+              source: #{manifold_config["metrics"]["taps"]["source"]}
+              breakouts:
+                paid: #{manifold_config["metrics"]["taps"]["breakouts"]["paid"]}
+              aggregations:
+                countif: #{manifold_config["metrics"]["taps"]["aggregations"]["countif"]}
+              filter: #{manifold_config["metrics"]["taps"]["filter"]}
         YAML
         workspace.write_manifold_merge_sql
       end
@@ -167,14 +173,6 @@ RSpec.describe Manifold::Terraform::WorkspaceConfiguration do
 
       it "includes countif metrics in the SQL file" do
         expect(routine_details[:sql_content]).to include("COUNTIF(IS_PAID(context.location)) AS tapCount")
-      end
-    end
-
-    context "when vectors have no merge configurations" do
-      before { config.add_vector(vector_config_without_merge) }
-
-      it "excludes routine configuration" do
-        expect(json["resource"]["google_bigquery_routine"]).to be_nil
       end
     end
   end

--- a/spec/support/shared_contexts/with_template_files.rb
+++ b/spec/support/shared_contexts/with_template_files.rb
@@ -6,14 +6,16 @@ RSpec.shared_context "with template files" do
 
     workspace_template_path.write(<<~YAML)
       vectors:
-      source: analytics.events
       timestamp:
         field: created_at
         interval: DAY
-      breakouts:
-        paid: IS_PAID(context.location)
-      aggregations:
-        countif: tapCount
+      metrics:
+        taps:
+          source: analytics.events
+          breakouts:
+            paid: IS_PAID(context.location)
+          aggregations:
+            countif: tapCount
     YAML
     vector_template_path.write("attributes:")
   end


### PR DESCRIPTION
Updates the Manifold schema to support multiple metric groups within the `metrics` struct. We can now support completely different metrics groups in a given manifold.

Each group contains its own:
  - Breakouts
  - Aggregations
  - Source table
  - Filter conditions
  
  ## Next Steps
Refactor the metrics merge strategy