### PR TITLE
Factor out SqlGenerator

### DIFF
--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -154,9 +154,11 @@ module Manifold
       end
 
       def write_dimensions_merge_sql
-        return unless dimensions_merge_source_exists?
+        return unless valid_dimensions_config?
 
-        sql = generate_dimensions_merge_sql
+        source_sql = File.read(Pathname.pwd.join(manifold_yaml["dimensions"]["merge"]["source"]))
+        sql_builder = Terraform::SQLBuilder.new(name, manifold_yaml)
+        sql = sql_builder.build_dimensions_merge_sql(source_sql)
         return unless sql
 
         write_dimensions_merge_sql_file(sql)
@@ -164,14 +166,6 @@ module Manifold
 
       def dimensions_merge_source_exists?
         manifold_yaml["dimensions"]&.dig("merge", "source")
-      end
-
-      def generate_dimensions_merge_sql
-        return unless valid_dimensions_config?
-
-        source_sql = File.read(Pathname.pwd.join(manifold_yaml["dimensions"]["merge"]["source"]))
-        sql_builder = Terraform::SQLBuilder.new(name, manifold_yaml)
-        sql_builder.build_dimensions_merge_sql(source_sql)
       end
 
       def valid_dimensions_config?

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -25,29 +25,6 @@ module Manifold
       end
     end
 
-    # Handles SQL generation for manifold workspaces
-    class SqlGenerator
-      def initialize(name, manifold_yaml)
-        @name = name
-        @manifold_yaml = manifold_yaml
-      end
-
-      def generate_dimensions_merge_sql(source_sql)
-        return unless valid_dimensions_config?
-
-        sql_builder = Terraform::SQLBuilder.new(@name, @manifold_yaml)
-        sql_builder.build_dimensions_merge_sql(source_sql)
-      end
-
-      private
-
-      def valid_dimensions_config?
-        return false unless @manifold_yaml
-
-        !@manifold_yaml["dimensions"]&.dig("merge", "source").nil?
-      end
-    end
-
     # Handles schema file generation for manifold workspaces
     class SchemaWriter
       def initialize(name, vectors, vector_service, manifold_yaml, logger)
@@ -190,8 +167,17 @@ module Manifold
       end
 
       def generate_dimensions_merge_sql
+        return unless valid_dimensions_config?
+
         source_sql = File.read(Pathname.pwd.join(manifold_yaml["dimensions"]["merge"]["source"]))
-        SqlGenerator.new(name, manifold_yaml).generate_dimensions_merge_sql(source_sql)
+        sql_builder = Terraform::SQLBuilder.new(name, manifold_yaml)
+        sql_builder.build_dimensions_merge_sql(source_sql)
+      end
+
+      def valid_dimensions_config?
+        return false unless manifold_yaml
+
+        !manifold_yaml["dimensions"]&.dig("merge", "source").nil?
       end
 
       def write_dimensions_merge_sql_file(sql)

--- a/lib/manifold/api/workspace.rb
+++ b/lib/manifold/api/workspace.rb
@@ -164,10 +164,6 @@ module Manifold
         write_dimensions_merge_sql_file(sql)
       end
 
-      def dimensions_merge_source_exists?
-        manifold_yaml["dimensions"]&.dig("merge", "source")
-      end
-
       def valid_dimensions_config?
         return false unless manifold_yaml
 


### PR DESCRIPTION
The SqlGenerator is essentially just a thin wrapper around SQLBuilder that only adds a validation check before delegating to SQLBuilder. No reason to keep it around.