### PR TITLE
Conditions and Breakouts

### DIFF
--- a/lib/manifold/api/schema_manager.rb
+++ b/lib/manifold/api/schema_manager.rb
@@ -162,19 +162,19 @@ module Manifold
         return [] unless group_config["breakouts"]
         return [] if group_config["breakouts"].keys.size <= 1
 
-        generate_all_breakout_combinations(group_config)
+        generate_intersections(group_config)
       end
 
-      def generate_all_breakout_combinations(group_config)
-        all_intersection_fields = []
+      def generate_intersections(group_config)
+        intersections = []
         breakout_groups = group_config["breakouts"].keys
 
         # Generate combinations of different sizes (2 to n breakout groups)
         (2..breakout_groups.size).each do |combination_size|
-          add_combinations_of_size(combination_size, breakout_groups, group_config, all_intersection_fields)
+          add_combinations_of_size(combination_size, breakout_groups, group_config, intersections)
         end
 
-        all_intersection_fields
+        intersections
       end
 
       def add_combinations_of_size(size, breakout_groups, group_config, all_fields)
@@ -206,13 +206,9 @@ module Manifold
       end
 
       def extend_combinations_with_remaining_sets(initial_combinations, remaining_sets)
-        combinations = initial_combinations
-
-        remaining_sets.each do |conditions|
-          combinations = extend_combinations_with_conditions(combinations, conditions)
+        remaining_sets.reduce(initial_combinations) do |combinations, conditions|
+          extend_combinations_with_conditions(combinations, conditions)
         end
-
-        combinations
       end
 
       def extend_combinations_with_conditions(existing_combinations, conditions)

--- a/lib/manifold/api/schema_manager.rb
+++ b/lib/manifold/api/schema_manager.rb
@@ -116,15 +116,142 @@ module Manifold
       end
 
       def group_metrics_fields(group_config)
-        return [] unless group_config["breakouts"] && group_config["aggregations"]
+        return [] unless group_config["aggregations"]
 
-        group_config["breakouts"].map do |breakout_name, _breakout_config|
-          {
+        # If there are no breakouts but there are complex logic operations,
+        # use the old-style format
+        if group_config["breakouts"]&.values&.any? { |v| v.is_a?(Hash) && v["operator"] }
+          # Legacy format handling - treat direct keys as breakouts
+          return handle_legacy_breakouts(group_config)
+        end
+
+        # If no breakouts defined at all, just return conditions/breakouts as is
+        unless group_config["breakouts"]
+          # Support for older format where breakouts are direct fields
+          # Add field for each explicitly defined condition or breakout
+          breakout_fields = (group_config.keys - %w[aggregations source filter]).map do |condition_name|
+            {
+              "name" => condition_name,
+              "type" => "RECORD",
+              "mode" => "NULLABLE",
+              "fields" => breakout_metrics_fields(group_config)
+            }
+          end
+          return breakout_fields
+        end
+
+        # Determine conditions list
+        conditions = if group_config["conditions"]
+                       group_config["conditions"].keys
+                     else
+                       # If no conditions defined, extract from breakouts
+                       extract_conditions_from_breakouts(group_config["breakouts"])
+                     end
+
+        # Generate individual condition fields
+        condition_fields = generate_condition_fields(conditions, group_config)
+
+        # Generate intersection fields across different breakout groups
+        intersection_fields = generate_breakout_intersection_fields(group_config)
+
+        condition_fields + intersection_fields
+      end
+
+      def handle_legacy_breakouts(group_config)
+        # For legacy format, each key directly in the metrics group is a breakout
+        breakout_fields = []
+
+        group_config["breakouts"].each_key do |breakout_name|
+          breakout_fields << {
             "name" => breakout_name,
             "type" => "RECORD",
             "mode" => "NULLABLE",
             "fields" => breakout_metrics_fields(group_config)
           }
+        end
+
+        breakout_fields
+      end
+
+      def extract_conditions_from_breakouts(breakouts)
+        # Handle both string and array formats for breakouts
+        conditions = []
+        breakouts.each do |breakout_name, breakout_values|
+          if breakout_values.is_a?(Array)
+            conditions.concat(breakout_values)
+          elsif breakout_values.is_a?(Hash) && breakout_values["operator"]
+            # Skip complex operators in the new format
+            next
+          else
+            # For string format, use the breakout name as the condition
+            conditions << breakout_name
+          end
+        end
+        conditions.uniq
+      end
+
+      def generate_condition_fields(conditions, group_config)
+        # Add a field for each condition
+        conditions.map do |condition_name|
+          {
+            "name" => condition_name,
+            "type" => "RECORD",
+            "mode" => "NULLABLE",
+            "fields" => breakout_metrics_fields(group_config)
+          }
+        end
+      end
+
+      def generate_breakout_intersection_fields(group_config)
+        return [] unless group_config["breakouts"]
+
+        intersection_fields = []
+        breakout_groups = group_config["breakouts"].keys
+
+        # Skip if there's only one breakout group or if using legacy format
+        return [] if breakout_groups.size <= 1 ||
+                     group_config["breakouts"].values.any? { |v| v.is_a?(Hash) && v["operator"] }
+
+        # Generate all possible combinations of conditions from different breakout groups
+        breakout_groups.combination(2).each do |breakout_pair|
+          # Get the conditions in each breakout group
+          first_group = breakout_pair[0]
+          second_group = breakout_pair[1]
+
+          first_group_conditions = get_breakout_conditions(group_config["breakouts"], first_group)
+          second_group_conditions = get_breakout_conditions(group_config["breakouts"], second_group)
+
+          # For each pair of conditions from different breakout groups, create an intersection field
+          first_group_conditions.each do |first_condition|
+            second_group_conditions.each do |second_condition|
+              # Format the intersection name with the second condition capitalized
+              intersection_name = "#{first_condition}#{second_condition.capitalize}"
+
+              intersection_fields << {
+                "name" => intersection_name,
+                "type" => "RECORD",
+                "mode" => "NULLABLE",
+                "fields" => breakout_metrics_fields(group_config)
+              }
+            end
+          end
+        end
+
+        intersection_fields
+      end
+
+      def get_breakout_conditions(breakouts, breakout_name)
+        breakout_value = breakouts[breakout_name]
+
+        if breakout_value.is_a?(Array)
+          # New format: breakout contains array of conditions
+          breakout_value
+        elsif breakout_value.is_a?(Hash) && breakout_value["operator"]
+          # Complex operator breakout - skip for now
+          []
+        else
+          # Legacy format: breakout name is the condition
+          [breakout_name]
         end
       end
 

--- a/lib/manifold/api/schema_manager.rb
+++ b/lib/manifold/api/schema_manager.rb
@@ -166,15 +166,14 @@ module Manifold
       end
 
       def generate_intersections(group_config)
-        intersections = []
         breakout_groups = group_config["breakouts"].keys
 
-        # Generate combinations of different sizes (2 to n breakout groups)
-        (2..breakout_groups.size).each do |combination_size|
-          add_combinations_of_size(combination_size, breakout_groups, group_config, intersections)
+        # Generate all valid combinations of breakout groups (sizes 2 to n)
+        (2..breakout_groups.size).flat_map do |size|
+          breakout_groups.combination(size).flat_map do |combo|
+            generate_intersection_fields_for_combination(group_config, combo)
+          end
         end
-
-        intersections
       end
 
       def add_combinations_of_size(size, breakout_groups, group_config, all_fields)

--- a/lib/manifold/api/schema_manager.rb
+++ b/lib/manifold/api/schema_manager.rb
@@ -212,15 +212,9 @@ module Manifold
       end
 
       def extend_combinations_with_conditions(existing_combinations, conditions)
-        new_combinations = []
-
-        existing_combinations.each do |existing_combination|
-          conditions.each do |condition|
-            new_combinations << (existing_combination + [condition])
-          end
+        existing_combinations.flat_map do |existing_combination|
+          conditions.map { |condition| existing_combination + [condition] }
         end
-
-        new_combinations
       end
 
       def create_intersection_fields(combinations, group_config)

--- a/lib/manifold/api/schema_manager.rb
+++ b/lib/manifold/api/schema_manager.rb
@@ -129,20 +129,12 @@ module Manifold
         return [] unless group_config["aggregations"]
 
         # Generate condition fields
-        condition_fields = generate_condition_fields(get_conditions_list(group_config), group_config)
+        condition_fields = generate_condition_fields(group_config["conditions"].keys, group_config)
 
         # Generate intersection fields between breakout groups
         intersection_fields = generate_breakout_intersection_fields(group_config)
 
         condition_fields + intersection_fields
-      end
-
-      def get_conditions_list(group_config)
-        if group_config["conditions"]
-          group_config["conditions"].keys
-        else
-          extract_conditions_from_breakouts(group_config["breakouts"])
-        end
       end
 
       def create_metric_field(field_name, group_config)
@@ -152,16 +144,6 @@ module Manifold
           "mode" => "NULLABLE",
           "fields" => breakout_metrics_fields(group_config)
         }
-      end
-
-      def extract_conditions_from_breakouts(breakouts)
-        return [] unless breakouts.is_a?(Hash)
-
-        conditions = []
-        breakouts.each_value do |breakout_values|
-          conditions.concat(breakout_values) if breakout_values.is_a?(Array)
-        end
-        conditions.uniq
       end
 
       def generate_condition_fields(conditions, group_config)

--- a/lib/manifold/services/vector_service.rb
+++ b/lib/manifold/services/vector_service.rb
@@ -4,7 +4,7 @@ module Manifold
   module Services
     # Handles the loading of vector schemas from configuration files
     class VectorService
-      def initialize(logger)
+      def initialize(logger = nil)
         @logger = logger
       end
 

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -24,6 +24,9 @@ metrics:
       device:
         - mobile
         - desktop
+      acquisition:
+        - organic
+        - paid
       region:
         - us
         - global

--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -14,9 +14,19 @@ timestamp:
 
 metrics:
   renders:
+    conditions:
+      mobile: IS_DESKTOP(context.device)
+      desktop: IS_MOBILE(context.device)
+      us: context.geo.country = 'US'
+      global: context.geo.country != 'US'
+    
     breakouts:
-      paid: IS_PAID(context.location)
-      organic: IS_ORGANIC(context.location)
+      device:
+        - mobile
+        - desktop
+      region:
+        - us
+        - global
 
     aggregations:
       countif: renderCount

--- a/lib/manifold/version.rb
+++ b/lib/manifold/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Manifold
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/manifold/api/schema_manager_spec.rb
+++ b/spec/manifold/api/schema_manager_spec.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+RSpec.describe Manifold::API::SchemaManager do
+  include FakeFS::SpecHelpers
+
+  subject(:schema_manager) { described_class.new(name, vectors, vector_service, manifold_yaml, logger) }
+
+  let(:logger) { instance_spy(Logger) }
+  let(:name) { "test_workspace" }
+  let(:vectors) { ["TestVector"] }
+  let(:vector_service) { instance_spy(Manifold::Services::VectorService) }
+  let(:manifold_yaml) do
+    {
+      "metrics" => {
+        "renders" => {
+          "conditions" => {
+            "mobile" => "IS_DESKTOP(context.device)",
+            "desktop" => "IS_MOBILE(context.device)",
+            "us" => "context.geo.country = 'US'",
+            "global" => "context.geo.country != 'US'"
+          },
+          "breakouts" => {
+            "device" => %w[mobile desktop],
+            "region" => %w[us global]
+          },
+          "aggregations" => {
+            "countif" => "renderCount",
+            "sumif" => {
+              "sequenceSum" => {
+                "field" => "context.sequence"
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+
+  before do
+    # Mock the vector service
+    allow(vector_service).to receive(:load_vector_schema).and_return(
+      { "name" => "test_vector", "type" => "STRING", "mode" => "NULLABLE" }
+    )
+  end
+
+  describe "#dimensions_schema" do
+    it "includes required id field" do
+      schema = schema_manager.dimensions_schema
+      expect(schema).to include(
+        { "type" => "STRING", "name" => "id", "mode" => "REQUIRED" }
+      )
+    end
+
+    it "includes dimensions field with RECORD type" do
+      schema = schema_manager.dimensions_schema
+      dimensions_field = schema.find { |f| f["name"] == "dimensions" }
+      expect(dimensions_field["type"]).to eq("RECORD")
+    end
+
+    it "includes dimensions field with REQUIRED mode" do
+      schema = schema_manager.dimensions_schema
+      dimensions_field = schema.find { |f| f["name"] == "dimensions" }
+      expect(dimensions_field["mode"]).to eq("REQUIRED")
+    end
+  end
+
+  describe "#manifold_schema" do
+    it "includes required id field" do
+      schema = schema_manager.manifold_schema
+      expect(schema).to include(
+        { "type" => "STRING", "name" => "id", "mode" => "REQUIRED" }
+      )
+    end
+
+    it "includes required timestamp field" do
+      schema = schema_manager.manifold_schema
+      expect(schema).to include(
+        { "type" => "TIMESTAMP", "name" => "timestamp", "mode" => "REQUIRED" }
+      )
+    end
+
+    it "includes dimensions field with RECORD type" do
+      schema = schema_manager.manifold_schema
+      dimensions_field = schema.find { |f| f["name"] == "dimensions" }
+      expect(dimensions_field["type"]).to eq("RECORD")
+    end
+
+    it "includes metrics field with RECORD type" do
+      schema = schema_manager.manifold_schema
+      metrics_field = schema.find { |f| f["name"] == "metrics" }
+      expect(metrics_field["type"]).to eq("RECORD")
+    end
+  end
+
+  describe "#metrics_fields" do
+    let(:metrics_fields) { schema_manager.send(:metrics_fields) }
+    let(:renders_field) { metrics_fields.find { |field| field["name"] == "renders" } }
+    let(:fields) { renders_field["fields"] }
+    let(:field_names) { fields.map { |field| field["name"] } }
+
+    it "includes the renders group field" do
+      expect(renders_field).not_to be_nil
+    end
+
+    it "includes all individual condition fields" do
+      expect(field_names).to include("mobile", "desktop", "us", "global")
+    end
+
+    it "includes intersection fields between different breakout groups" do
+      # We support both naming conventions (first to second or second to first)
+      mobile_us_present = field_names.include?("mobileUs") || field_names.include?("usMobile")
+      desktop_us_present = field_names.include?("desktopUs") || field_names.include?("usDesktop")
+      mobile_global_present = field_names.include?("mobileGlobal") || field_names.include?("globalMobile")
+      desktop_global_present = field_names.include?("desktopGlobal") || field_names.include?("globalDesktop")
+
+      expect(mobile_us_present).to be(true)
+      expect(desktop_us_present).to be(true)
+      expect(mobile_global_present).to be(true)
+      expect(desktop_global_present).to be(true)
+    end
+
+    it "does not include intersection fields from the same breakout group" do
+      # Should not include mobile/desktop combinations (same breakout)
+      expect(field_names).not_to include("mobileDesktop")
+      expect(field_names).not_to include("desktopMobile")
+
+      # Should not include us/global combinations (same breakout)
+      expect(field_names).not_to include("usGlobal")
+      expect(field_names).not_to include("globalUs")
+    end
+
+    it "includes correct aggregation fields for individual conditions" do
+      mobile_field = fields.find { |field| field["name"] == "mobile" }
+      expect(mobile_field["fields"].map { |f| f["name"] }).to include("renderCount", "sequenceSum")
+    end
+
+    it "includes correct aggregation fields for intersection conditions" do
+      # Find an intersection field (using either naming convention)
+      intersection_field = fields.find do |field|
+        field["name"] == "mobileUs" || field["name"] == "usMobile"
+      end
+
+      expect(intersection_field).not_to be_nil
+      expect(intersection_field["fields"].map { |f| f["name"] }).to include("renderCount", "sequenceSum")
+    end
+  end
+
+  context "when conditions are not explicitly defined" do
+    let(:manifold_yaml) do
+      {
+        "metrics" => {
+          "renders" => {
+            "breakouts" => {
+              "device" => %w[mobile desktop],
+              "region" => %w[us global]
+            },
+            "aggregations" => {
+              "countif" => "renderCount"
+            }
+          }
+        }
+      }
+    end
+
+    let(:metrics_fields) { schema_manager.send(:metrics_fields) }
+    let(:renders_field) { metrics_fields.find { |field| field["name"] == "renders" } }
+    let(:fields) { renders_field["fields"] }
+    let(:field_names) { fields.map { |field| field["name"] } }
+
+    it "derives condition fields from breakouts" do
+      expect(field_names).to include("mobile", "desktop", "us", "global")
+    end
+
+    it "still generates intersection fields" do
+      # Check for either naming convention
+      mobile_us_present = field_names.include?("mobileUs") || field_names.include?("usMobile")
+      desktop_us_present = field_names.include?("desktopUs") || field_names.include?("usDesktop")
+
+      expect(mobile_us_present).to be(true)
+      expect(desktop_us_present).to be(true)
+    end
+  end
+
+  describe "#write_schemas" do
+    let(:tables_directory) { Pathname.pwd.join("tables") }
+
+    before do
+      tables_directory.mkpath
+      schema_manager.write_schemas(tables_directory)
+    end
+
+    it "generates a dimensions schema file" do
+      expect(tables_directory.join("dimensions.json")).to be_file
+    end
+
+    it "generates a manifold schema file" do
+      expect(tables_directory.join("manifold.json")).to be_file
+    end
+
+    it "generates a metrics directory" do
+      expect(tables_directory.join("metrics")).to be_directory
+    end
+
+    it "generates a metrics schema file for each metrics group" do
+      expect(tables_directory.join("metrics/renders.json")).to be_file
+    end
+  end
+end

--- a/spec/manifold/api/schema_manager_spec.rb
+++ b/spec/manifold/api/schema_manager_spec.rb
@@ -169,49 +169,6 @@ RSpec.describe Manifold::API::SchemaManager do
     end
   end
 
-  describe "when conditions are not explicitly defined" do
-    subject(:conditional_fields) { metric_render_fields }
-
-    let(:manifold_yaml) do
-      {
-        "metrics" => {
-          "renders" => {
-            "breakouts" => {
-              "device" => %w[mobile desktop],
-              "region" => %w[us global]
-            },
-            "aggregations" => {
-              "countif" => "renderCount"
-            }
-          }
-        }
-      }
-    end
-
-    def metric_render_fields
-      metrics_fields = schema_manager.send(:metrics_fields)
-      renders_field = metrics_fields.find { |field| field["name"] == "renders" }
-      renders_field["fields"]
-    end
-
-    it "derives condition fields from breakouts" do
-      condition_names = conditional_fields.map { |field| field["name"] }
-      expect(condition_names).to include("mobile", "desktop", "us", "global")
-    end
-
-    it "generates mobile-us intersection" do
-      condition_names = conditional_fields.map { |field| field["name"] }
-      mobile_us_variants = %w[mobileUs usMobile]
-      expect(mobile_us_variants.any? { |variant| condition_names.include?(variant) }).to be true
-    end
-
-    it "generates desktop-us intersection" do
-      condition_names = conditional_fields.map { |field| field["name"] }
-      desktop_us_variants = %w[desktopUs usDesktop]
-      expect(desktop_us_variants.any? { |variant| condition_names.include?(variant) }).to be true
-    end
-  end
-
   describe "#write_schemas" do
     subject(:tables_dir) { Pathname.pwd.join("tables") }
 

--- a/spec/manifold/api/workspace_spec.rb
+++ b/spec/manifold/api/workspace_spec.rb
@@ -107,6 +107,8 @@ RSpec.describe Manifold::API::Workspace do
                 organic: IS_ORGANIC(context.location)
                 us: context.geo.country = 'US'
                 global: context.geo.country != 'US'
+                retargeting: context.campaign_type = 'RETARGETING'
+                prospecting: context.campaign_type = 'PROSPECTING'
 
               breakouts:
                 acquisition:
@@ -115,6 +117,9 @@ RSpec.describe Manifold::API::Workspace do
                 geography:
                   - us
                   - global
+                campaign:
+                  - retargeting
+                  - prospecting
 
               aggregations:
                 countif: tapCount
@@ -256,12 +261,32 @@ RSpec.describe Manifold::API::Workspace do
       include_examples "breakout metrics", "organic"
       include_examples "breakout metrics", "us"
       include_examples "breakout metrics", "global"
+      include_examples "breakout metrics", "retargeting"
+      include_examples "breakout metrics", "prospecting"
 
-      # Test intersection fields
+      # Test two-way intersection fields
       include_examples "breakout metrics", "paidUs"
       include_examples "breakout metrics", "paidGlobal"
       include_examples "breakout metrics", "organicUs"
       include_examples "breakout metrics", "organicGlobal"
+      include_examples "breakout metrics", "paidRetargeting"
+      include_examples "breakout metrics", "paidProspecting"
+      include_examples "breakout metrics", "organicRetargeting"
+      include_examples "breakout metrics", "organicProspecting"
+      include_examples "breakout metrics", "usRetargeting"
+      include_examples "breakout metrics", "usProspecting"
+      include_examples "breakout metrics", "globalRetargeting"
+      include_examples "breakout metrics", "globalProspecting"
+
+      # Test three-way intersection fields
+      include_examples "breakout metrics", "paidUsRetargeting"
+      include_examples "breakout metrics", "paidUsProspecting"
+      include_examples "breakout metrics", "paidGlobalRetargeting"
+      include_examples "breakout metrics", "paidGlobalProspecting"
+      include_examples "breakout metrics", "organicUsRetargeting"
+      include_examples "breakout metrics", "organicUsProspecting"
+      include_examples "breakout metrics", "organicGlobalRetargeting"
+      include_examples "breakout metrics", "organicGlobalProspecting"
 
       it "includes all condition fields and intersection fields in the metrics fields" do
         expect(schema_fields[:metrics]["fields"]
@@ -272,8 +297,12 @@ RSpec.describe Manifold::API::Workspace do
 
       def expected_field_names
         %w[
-          paid organic us global
+          paid organic us global retargeting prospecting
           paidUs paidGlobal organicUs organicGlobal
+          paidRetargeting paidProspecting organicRetargeting organicProspecting
+          usRetargeting usProspecting globalRetargeting globalProspecting
+          paidUsRetargeting paidUsProspecting paidGlobalRetargeting paidGlobalProspecting
+          organicUsRetargeting organicUsProspecting organicGlobalRetargeting organicGlobalProspecting
         ]
       end
 


### PR DESCRIPTION
Differentiates the concept of a `condition` from a `breakout`. Metrics schemas provide fields for each condition on its own, as well as the intersection of all conditions across all groups (though never *within* a given group).

Conditions provide the simple definitions used to group events. For example, `us` might mean the event's `context.geo.country = 'US'`. Breakouts describe groups of conditions that are mutually exclusive. For example, if an event is `us` then it is necessarily not `global`, or `mobile` and necessarily not `tablet`. 

Breakouts can be intersected to produce `mobileUs` or `tabletGlobal` but never `usGlobal`.