### PR TITLE
Partition Configuration

### DIFF
--- a/lib/manifold/templates/workspace_template.yml
+++ b/lib/manifold/templates/workspace_template.yml
@@ -12,6 +12,9 @@ timestamp:
   interval: HOUR
   field: timestamp
 
+partitioning:
+  interval: HOUR
+
 metrics:
   renders:
     conditions:


### PR DESCRIPTION
Enables configuring partition intervals on manifolds. The same partition interval is applied to the manifold table and all metrics tables. The partition field is always **timestamp**. It's an optional config. If you leave it out, no partitioning strategy will be applied to your tables.